### PR TITLE
ci(dockerfile): update docker base image to correct version on dockerhub

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,7 @@ RUN apt-get update -y && apt-get install -y libstdc++6 openssl libncurses5 local
     && apt-get clean && rm -f /var/lib/apt/lists/*_* \
     && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 
-ENV LANG en_US.utf8
+ENV LANG=en_US.utf8
 
 WORKDIR /app
 


### PR DESCRIPTION
- Use elixir:1.18-otp-27-slim for build stage
- Fix ENV format for LANG