### PR TITLE
Meeting notes

### DIFF
--- a/lib/dashboard_ssd/integrations/fireflies.ex
+++ b/lib/dashboard_ssd/integrations/fireflies.ex
@@ -296,4 +296,224 @@ defmodule DashboardSSD.Integrations.Fireflies do
         :ok
     end
   end
+
+  # ================= Per-event and batched notes =================
+
+  @doc """
+  Fetch notes for a specific meeting occurrence (by event map).
+
+  The `event` map should include keys:
+    * `:id` - calendar event id (string)
+    * `:starts_at`, `:ends_at` - DateTime.t()
+    * `:title` - meeting title (string, optional but recommended)
+    * `:participants` - [email] (optional)
+    * `:meeting_link` - URL (optional; used for exact match when present)
+
+  Returns `{:ok, %{accomplished, action_items, bullet_gist, transcript_id}}`,
+  `:not_found`, or `{:error, term}`.
+  """
+  @spec fetch_notes_for_event(map(), keyword()) ::
+          {:ok,
+           %{
+             accomplished: String.t() | nil,
+             action_items: [String.t()],
+             bullet_gist: String.t() | nil,
+             transcript_id: String.t() | nil
+           }}
+          | :not_found
+          | {:error, term()}
+  def fetch_notes_for_event(event, opts \\ []) when is_map(event) do
+    with {:ok, from_iso, to_iso} <- time_window_iso(event, opts),
+         {:ok, transcripts} <-
+           FirefliesClient.list_transcripts(
+             Keyword.merge(
+               [
+                 from_date: from_iso,
+                 to_date: to_iso,
+                 limit: Keyword.get(opts, :limit, 50)
+               ],
+               participants_filter(event)
+             )
+           ) do
+      case select_transcript_for_event(event, transcripts) do
+        {:ok, t} -> {:ok, normalize_transcript_summary(t)}
+        :not_found -> :not_found
+      end
+    end
+  end
+
+  @doc """
+  Batch version for a list of events. Performs a single transcripts query for the
+  window spanning all events, then maps results locally.
+
+  Returns `{:ok, %{event_id => note_map}}` for the matched subset.
+  """
+  @spec fetch_notes_for_events([map()], keyword()) :: {:ok, map()} | {:error, term()}
+  def fetch_notes_for_events(events, opts \\ []) when is_list(events) do
+    case time_window_for_events(events, opts) do
+      {:ok, from_iso, to_iso} ->
+        with {:ok, transcripts} <-
+               FirefliesClient.list_transcripts(
+                 [from_date: from_iso, to_date: to_iso, limit: Keyword.get(opts, :limit, 200)]
+               ) do
+          mapped =
+            Enum.reduce(events, %{}, fn ev, acc ->
+              case select_transcript_for_event(ev, transcripts) do
+                {:ok, t} -> Map.put(acc, ev[:id] || ev["id"], normalize_transcript_summary(t))
+                :not_found -> acc
+              end
+            end)
+
+          {:ok, mapped}
+        end
+
+      {:error, _} = err -> err
+    end
+  end
+
+  # -- selection helpers --
+
+  defp participants_filter(%{participants: ps}) when is_list(ps) and ps != [] do
+    [participants: Enum.filter(ps, &is_binary/1)]
+  end
+
+  defp participants_filter(_), do: []
+
+  defp time_window_iso(%{starts_at: s, ends_at: e}, opts) do
+    pad_secs = Keyword.get(opts, :pad_seconds, 300)
+    with {:ok, s2} <- shift_seconds(s, -pad_secs),
+         {:ok, e2} <- shift_seconds(e, pad_secs) do
+      {:ok, DateTime.to_iso8601(s2), DateTime.to_iso8601(e2)}
+    else
+      _ -> {:error, :invalid_time}
+    end
+  end
+
+  defp time_window_iso(_, _), do: {:error, :invalid_time}
+
+  defp time_window_for_events(events, opts) do
+    pad_secs = Keyword.get(opts, :pad_seconds, 300)
+
+    times =
+      events
+      |> Enum.flat_map(fn ev -> [ev[:starts_at] || ev["starts_at"], ev[:ends_at] || ev["ends_at"]] end)
+      |> Enum.filter(&match?(%DateTime{}, &1))
+
+    case times do
+      [] -> {:error, :invalid_time}
+      _ ->
+        min_t = Enum.min(times, DateTime)
+        max_t = Enum.max(times, DateTime)
+        with {:ok, s2} <- shift_seconds(min_t, -pad_secs),
+             {:ok, e2} <- shift_seconds(max_t, pad_secs) do
+          {:ok, DateTime.to_iso8601(s2), DateTime.to_iso8601(e2)}
+        else
+          _ -> {:error, :invalid_time}
+        end
+    end
+  end
+
+  defp shift_seconds(%DateTime{} = dt, sec) when is_integer(sec) do
+    {:ok, DateTime.add(dt, sec, :second)}
+  end
+
+  defp select_transcript_for_event(event, transcripts) when is_list(transcripts) do
+    link = event[:meeting_link] || event["meeting_link"]
+
+    with {:ok, by_link} <- pick_by_meeting_link(event, link, transcripts) do
+      {:ok, by_link}
+    else
+      _ ->
+        pick_by_time_and_title(event, transcripts)
+    end
+  end
+
+  defp pick_by_meeting_link(_event, nil, _), do: {:error, :no_link}
+  defp pick_by_meeting_link(_event, "", _), do: {:error, :no_link}
+
+  defp pick_by_meeting_link(event, link, transcripts) do
+    matches =
+      transcripts
+      |> Enum.filter(fn t ->
+        (Map.get(t, "meeting_link") || Map.get(t, :meeting_link)) == link
+      end)
+
+    case matches do
+      [] -> {:error, :not_found}
+      [_one] -> {:ok, List.first(matches)}
+      many -> {:ok, closest_by_time(many, event_start(event))}
+    end
+  end
+
+  defp pick_by_time_and_title(event, transcripts) do
+    start = event_start(event)
+    title = event[:title] || event["title"] || ""
+
+    candidates =
+      transcripts
+      |> Enum.map(fn t ->
+        {t, transcript_time(t), title_similarity(title, t)}
+      end)
+      |> Enum.reject(fn {_t, tdt, _score} -> is_nil(tdt) end)
+
+    case candidates do
+      [] -> :not_found
+      list ->
+        {best, best_dt, _score} =
+          list
+          |> Enum.min_by(fn {_t, tdt, _} -> abs_diff_sec(start, tdt) end)
+
+        # Basic sanity threshold: 6 hours by default
+        if abs_diff_sec(start, best_dt) <= 6 * 3600 do
+          {:ok, best}
+        else
+          :not_found
+        end
+    end
+  end
+
+  defp event_start(ev), do: ev[:starts_at] || ev["starts_at"]
+
+  defp transcript_time(t) do
+    case Map.get(t, "date") || Map.get(t, :date) do
+      nil -> nil
+      iso when is_binary(iso) ->
+        case DateTime.from_iso8601(iso) do
+          {:ok, dt, _} -> dt
+          _ -> nil
+        end
+    end
+  end
+
+  defp title_similarity(title, t) do
+    t_title = Map.get(t, "title") || Map.get(t, :title) || ""
+    similarity(normalize(title), normalize(to_string(t_title)))
+  end
+
+  defp abs_diff_sec(%DateTime{} = a, %DateTime{} = b) do
+    abs(DateTime.diff(a, b, :second))
+  end
+
+  defp closest_by_time(list, %DateTime{} = ref) do
+    list
+    |> Enum.min_by(fn t ->
+      case transcript_time(t) do
+        %DateTime{} = dt -> abs(DateTime.diff(dt, ref, :second))
+        _ -> 1_000_000_000
+      end
+    end)
+  end
+
+  defp normalize_transcript_summary(t) when is_map(t) do
+    sum = Map.get(t, "summary") || Map.get(t, :summary) || %{}
+    items = Map.get(sum, "action_items") || Map.get(sum, :action_items) || []
+    notes = Map.get(sum, "overview") || Map.get(sum, :overview) || Map.get(sum, "short_summary")
+    bullet = Map.get(sum, "bullet_gist") || Map.get(sum, :bullet_gist)
+    %{
+      accomplished: notes,
+      action_items: normalize_items_to_list(items),
+      bullet_gist: bullet,
+      transcript_id: Map.get(t, "id") || Map.get(t, :id)
+    }
+  end
 end

--- a/lib/dashboard_ssd/integrations/fireflies.ex
+++ b/lib/dashboard_ssd/integrations/fireflies.ex
@@ -483,50 +483,33 @@ defmodule DashboardSSD.Integrations.Fireflies do
 
   defp event_start(ev), do: ev[:starts_at] || ev["starts_at"]
 
-  defp transcript_time(t) do
-    case Map.get(t, "date") || Map.get(t, :date) do
-      nil ->
-        nil
+  defp transcript_time(%{"date" => d}), do: parse_transcript_date(d)
+  defp transcript_time(%{date: d}), do: parse_transcript_date(d)
+  defp transcript_time(_), do: nil
 
-      iso when is_binary(iso) ->
-        case DateTime.from_iso8601(iso) do
-          {:ok, dt, _} -> dt
-          _ -> nil
-        end
-
-      ts when is_integer(ts) ->
-        # Treat large integers as epoch milliseconds; otherwise seconds.
-        if ts > 9_999_999_999 do
-          case DateTime.from_unix(ts, :millisecond) do
-            {:ok, dt} -> dt
-            _ -> nil
-          end
-        else
-          case DateTime.from_unix(ts) do
-            {:ok, dt} -> dt
-            _ -> nil
-          end
-        end
-
-      ts when is_float(ts) ->
-        i = round(ts)
-
-        if i > 9_999_999_999 do
-          case DateTime.from_unix(i, :millisecond) do
-            {:ok, dt} -> dt
-            _ -> nil
-          end
-        else
-          case DateTime.from_unix(i) do
-            {:ok, dt} -> dt
-            _ -> nil
-          end
-        end
-
-      _ ->
-        nil
+  defp parse_transcript_date(iso) when is_binary(iso) do
+    case DateTime.from_iso8601(iso) do
+      {:ok, dt, _} -> dt
+      _ -> nil
     end
   end
+
+  defp parse_transcript_date(ts) when is_integer(ts) do
+    if ts > 9_999_999_999 do
+      case DateTime.from_unix(ts, :millisecond) do
+        {:ok, dt} -> dt
+        _ -> nil
+      end
+    else
+      case DateTime.from_unix(ts) do
+        {:ok, dt} -> dt
+        _ -> nil
+      end
+    end
+  end
+
+  defp parse_transcript_date(ts) when is_float(ts), do: parse_transcript_date(round(ts))
+  defp parse_transcript_date(_), do: nil
 
   defp title_similarity(title, t) do
     t_title = Map.get(t, "title") || Map.get(t, :title) || ""

--- a/lib/dashboard_ssd/integrations/fireflies.ex
+++ b/lib/dashboard_ssd/integrations/fireflies.ex
@@ -342,7 +342,6 @@ defmodule DashboardSSD.Integrations.Fireflies do
     else
       {:error, {:rate_limited, _} = rl} -> {:error, rl}
       {:error, _} = err -> err
-      _ -> :not_found
     end
   end
 

--- a/lib/dashboard_ssd/integrations/fireflies.ex
+++ b/lib/dashboard_ssd/integrations/fireflies.ex
@@ -495,6 +495,38 @@ defmodule DashboardSSD.Integrations.Fireflies do
           {:ok, dt, _} -> dt
           _ -> nil
         end
+
+      ts when is_integer(ts) ->
+        # Treat large integers as epoch milliseconds; otherwise seconds.
+        if ts > 9_999_999_999 do
+          case DateTime.from_unix(ts, :millisecond) do
+            {:ok, dt} -> dt
+            _ -> nil
+          end
+        else
+          case DateTime.from_unix(ts) do
+            {:ok, dt} -> dt
+            _ -> nil
+          end
+        end
+
+      ts when is_float(ts) ->
+        i = round(ts)
+
+        if i > 9_999_999_999 do
+          case DateTime.from_unix(i, :millisecond) do
+            {:ok, dt} -> dt
+            _ -> nil
+          end
+        else
+          case DateTime.from_unix(i) do
+            {:ok, dt} -> dt
+            _ -> nil
+          end
+        end
+
+      _ ->
+        nil
     end
   end
 

--- a/lib/dashboard_ssd/integrations/fireflies.ex
+++ b/lib/dashboard_ssd/integrations/fireflies.ex
@@ -350,28 +350,24 @@ defmodule DashboardSSD.Integrations.Fireflies do
   """
   @spec fetch_notes_for_events([map()], keyword()) :: {:ok, map()} | {:error, term()}
   def fetch_notes_for_events(events, opts \\ []) when is_list(events) do
-    case time_window_for_events(events, opts) do
-      {:ok, from_iso, to_iso} ->
-        with {:ok, transcripts} <-
-               FirefliesClient.list_transcripts(
-                 from_date: from_iso,
-                 to_date: to_iso,
-                 limit: Keyword.get(opts, :limit, 200)
-               ) do
-          mapped =
-            Enum.reduce(events, %{}, fn ev, acc ->
-              case select_transcript_for_event(ev, transcripts) do
-                {:ok, t} -> Map.put(acc, ev[:id] || ev["id"], normalize_transcript_summary(t))
-                :not_found -> acc
-              end
-            end)
-
-          {:ok, mapped}
-        end
-
-      {:error, _} = err ->
-        err
+    with {:ok, from_iso, to_iso} <- time_window_for_events(events, opts),
+         {:ok, transcripts} <-
+           FirefliesClient.list_transcripts(
+             from_date: from_iso,
+             to_date: to_iso,
+             limit: Keyword.get(opts, :limit, 200)
+           ) do
+      {:ok, map_events_to_notes(events, transcripts)}
     end
+  end
+
+  defp map_events_to_notes(events, transcripts) do
+    Enum.reduce(events, %{}, fn ev, acc ->
+      case select_transcript_for_event(ev, transcripts) do
+        {:ok, t} -> Map.put(acc, ev[:id] || ev["id"], normalize_transcript_summary(t))
+        :not_found -> acc
+      end
+    end)
   end
 
   # -- selection helpers --

--- a/lib/dashboard_ssd/integrations/fireflies.ex
+++ b/lib/dashboard_ssd/integrations/fireflies.ex
@@ -429,11 +429,9 @@ defmodule DashboardSSD.Integrations.Fireflies do
   defp select_transcript_for_event(event, transcripts) when is_list(transcripts) do
     link = event[:meeting_link] || event["meeting_link"]
 
-    with {:ok, by_link} <- pick_by_meeting_link(event, link, transcripts) do
-      {:ok, by_link}
-    else
-      _ ->
-        pick_by_time_and_title(event, transcripts)
+    case pick_by_meeting_link(event, link, transcripts) do
+      {:ok, by_link} -> {:ok, by_link}
+      _ -> pick_by_time_and_title(event, transcripts)
     end
   end
 

--- a/lib/dashboard_ssd/integrations/fireflies.ex
+++ b/lib/dashboard_ssd/integrations/fireflies.ex
@@ -339,6 +339,10 @@ defmodule DashboardSSD.Integrations.Fireflies do
         {:ok, t} -> {:ok, normalize_transcript_summary(t)}
         :not_found -> :not_found
       end
+    else
+      {:error, {:rate_limited, _} = rl} -> {:error, rl}
+      {:error, _} = err -> err
+      _ -> :not_found
     end
   end
 

--- a/lib/dashboard_ssd/integrations/fireflies.ex
+++ b/lib/dashboard_ssd/integrations/fireflies.ex
@@ -354,7 +354,9 @@ defmodule DashboardSSD.Integrations.Fireflies do
       {:ok, from_iso, to_iso} ->
         with {:ok, transcripts} <-
                FirefliesClient.list_transcripts(
-                 [from_date: from_iso, to_date: to_iso, limit: Keyword.get(opts, :limit, 200)]
+                 from_date: from_iso,
+                 to_date: to_iso,
+                 limit: Keyword.get(opts, :limit, 200)
                ) do
           mapped =
             Enum.reduce(events, %{}, fn ev, acc ->
@@ -367,7 +369,8 @@ defmodule DashboardSSD.Integrations.Fireflies do
           {:ok, mapped}
         end
 
-      {:error, _} = err -> err
+      {:error, _} = err ->
+        err
     end
   end
 
@@ -381,6 +384,7 @@ defmodule DashboardSSD.Integrations.Fireflies do
 
   defp time_window_iso(%{starts_at: s, ends_at: e}, opts) do
     pad_secs = Keyword.get(opts, :pad_seconds, 300)
+
     with {:ok, s2} <- shift_seconds(s, -pad_secs),
          {:ok, e2} <- shift_seconds(e, pad_secs) do
       {:ok, DateTime.to_iso8601(s2), DateTime.to_iso8601(e2)}
@@ -396,14 +400,19 @@ defmodule DashboardSSD.Integrations.Fireflies do
 
     times =
       events
-      |> Enum.flat_map(fn ev -> [ev[:starts_at] || ev["starts_at"], ev[:ends_at] || ev["ends_at"]] end)
+      |> Enum.flat_map(fn ev ->
+        [ev[:starts_at] || ev["starts_at"], ev[:ends_at] || ev["ends_at"]]
+      end)
       |> Enum.filter(&match?(%DateTime{}, &1))
 
     case times do
-      [] -> {:error, :invalid_time}
+      [] ->
+        {:error, :invalid_time}
+
       _ ->
         min_t = Enum.min(times, DateTime)
         max_t = Enum.max(times, DateTime)
+
         with {:ok, s2} <- shift_seconds(min_t, -pad_secs),
              {:ok, e2} <- shift_seconds(max_t, pad_secs) do
           {:ok, DateTime.to_iso8601(s2), DateTime.to_iso8601(e2)}
@@ -457,7 +466,9 @@ defmodule DashboardSSD.Integrations.Fireflies do
       |> Enum.reject(fn {_t, tdt, _score} -> is_nil(tdt) end)
 
     case candidates do
-      [] -> :not_found
+      [] ->
+        :not_found
+
       list ->
         {best, best_dt, _score} =
           list
@@ -476,7 +487,9 @@ defmodule DashboardSSD.Integrations.Fireflies do
 
   defp transcript_time(t) do
     case Map.get(t, "date") || Map.get(t, :date) do
-      nil -> nil
+      nil ->
+        nil
+
       iso when is_binary(iso) ->
         case DateTime.from_iso8601(iso) do
           {:ok, dt, _} -> dt
@@ -509,6 +522,7 @@ defmodule DashboardSSD.Integrations.Fireflies do
     items = Map.get(sum, "action_items") || Map.get(sum, :action_items) || []
     notes = Map.get(sum, "overview") || Map.get(sum, :overview) || Map.get(sum, "short_summary")
     bullet = Map.get(sum, "bullet_gist") || Map.get(sum, :bullet_gist)
+
     %{
       accomplished: notes,
       action_items: normalize_items_to_list(items),

--- a/lib/dashboard_ssd/meetings/meeting_note.ex
+++ b/lib/dashboard_ssd/meetings/meeting_note.ex
@@ -71,4 +71,3 @@ defmodule DashboardSSD.Meetings.MeetingNote do
 
   defp normalize_action_items_attr(attrs), do: attrs
 end
-

--- a/lib/dashboard_ssd/meetings/meeting_note.ex
+++ b/lib/dashboard_ssd/meetings/meeting_note.ex
@@ -1,0 +1,74 @@
+defmodule DashboardSSD.Meetings.MeetingNote do
+  @moduledoc """
+  Ecto schema for per-occurrence meeting notes aligned to a specific
+  calendar event and local occurrence date.
+
+  This stores normalized notes fetched from Fireflies (or other sources),
+  keyed by `calendar_event_id` and `occurrence_date`.
+  """
+
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @type t :: %__MODULE__{
+          id: integer() | nil,
+          calendar_event_id: String.t() | nil,
+          recurring_series_id: String.t() | nil,
+          occurrence_date: Date.t() | nil,
+          transcript_id: String.t() | nil,
+          accomplished: String.t() | nil,
+          bullet_gist: String.t() | nil,
+          action_items: list() | map() | nil,
+          fetched_at: DateTime.t() | nil
+        }
+
+  schema "meeting_notes" do
+    field :calendar_event_id, :string
+    field :recurring_series_id, :string
+    field :occurrence_date, :date
+    field :transcript_id, :string
+    field :accomplished, :string
+    field :bullet_gist, :string
+    field :action_items, :map
+    field :fetched_at, :utc_datetime
+    timestamps(type: :utc_datetime)
+  end
+
+  @doc false
+  @spec changeset(t(), map()) :: Ecto.Changeset.t()
+  def changeset(note, attrs) do
+    attrs = normalize_action_items_attr(attrs)
+
+    note
+    |> cast(attrs, [
+      :calendar_event_id,
+      :recurring_series_id,
+      :occurrence_date,
+      :transcript_id,
+      :accomplished,
+      :bullet_gist,
+      :action_items,
+      :fetched_at
+    ])
+    |> validate_required([:calendar_event_id, :occurrence_date])
+    |> unique_constraint(:calendar_event_id,
+      name: :meeting_notes_calendar_event_id_occurrence_date_index
+    )
+  end
+
+  defp normalize_action_items_attr(attrs) when is_map(attrs) do
+    cond do
+      is_list(Map.get(attrs, :action_items)) ->
+        Map.put(attrs, :action_items, %{"items" => Map.get(attrs, :action_items)})
+
+      is_list(Map.get(attrs, "action_items")) ->
+        Map.put(attrs, "action_items", %{"items" => Map.get(attrs, "action_items")})
+
+      true ->
+        attrs
+    end
+  end
+
+  defp normalize_action_items_attr(attrs), do: attrs
+end
+

--- a/lib/dashboard_ssd/meetings/notes.ex
+++ b/lib/dashboard_ssd/meetings/notes.ex
@@ -195,4 +195,11 @@ defmodule DashboardSSD.Meetings.Notes do
       note -> persist_and_cache(ev, date, note)
     end
   end
+
+  defp future_event?(event) do
+    case event[:starts_at] || event["starts_at"] do
+      %DateTime{} = dt -> DateTime.compare(dt, DateTime.utc_now()) == :gt
+      _ -> false
+    end
+  end
 end

--- a/lib/dashboard_ssd/meetings/notes.ex
+++ b/lib/dashboard_ssd/meetings/notes.ex
@@ -147,23 +147,26 @@ defmodule DashboardSSD.Meetings.Notes do
   defp fetch_batch_and_persist([], _events, _opts), do: {:ok, %{}}
 
   defp fetch_batch_and_persist(still_missing, events, opts) do
-    if Keyword.get(opts, :skip_remote, false) do
-      {:ok, %{}}
-    else
-      case Fireflies.fetch_notes_for_events(events, opts) do
-        {:ok, mapped} when is_map(mapped) ->
-          Enum.each(still_missing, fn {id, date, ev} ->
-            case Map.get(mapped, id) do
-              nil -> :noop
-              note -> persist_and_cache(ev, date, note)
-            end
-          end)
-
-          {:ok, mapped}
-
-        {:error, _} = err ->
-          err
+    result =
+      if Keyword.get(opts, :skip_remote, false) do
+        {:ok, %{}}
+      else
+        Fireflies.fetch_notes_for_events(events, opts)
       end
+
+    case result do
+      {:ok, mapped} when is_map(mapped) ->
+        Enum.each(still_missing, fn {id, date, ev} ->
+          case Map.get(mapped, id) do
+            nil -> :noop
+            note -> persist_and_cache(ev, date, note)
+          end
+        end)
+
+        {:ok, mapped}
+
+      {:error, _} = err ->
+        err
     end
   end
 end

--- a/lib/dashboard_ssd/meetings/notes.ex
+++ b/lib/dashboard_ssd/meetings/notes.ex
@@ -4,8 +4,8 @@ defmodule DashboardSSD.Meetings.Notes do
   cache → DB → remote (Fireflies) strategy. Supports batched retrieval.
   """
 
-  alias DashboardSSD.Meetings.{CacheStore, NotesStore}
   alias DashboardSSD.Integrations.Fireflies
+  alias DashboardSSD.Meetings.{CacheStore, NotesStore}
 
   @type event_map :: map()
   @type note_map :: %{

--- a/lib/dashboard_ssd/meetings/notes.ex
+++ b/lib/dashboard_ssd/meetings/notes.ex
@@ -40,41 +40,11 @@ defmodule DashboardSSD.Meetings.Notes do
   """
   @spec get_or_fetch_many([event_map], keyword()) :: {:ok, map()} | {:error, term}
   def get_or_fetch_many(events, opts \\ []) when is_list(events) do
-    # Partition cache hits and misses
-    {hits, misses} =
-      events
-      |> Enum.reduce({%{}, []}, fn ev, {acc, missing} ->
-        case event_id_and_date(ev) do
-          {:ok, id, date} ->
-            key = {:meeting_notes, id, date}
-
-            case CacheStore.get(key) do
-              {:ok, note} -> {Map.put(acc, id, note), missing}
-              :miss -> {acc, [{id, date, ev} | missing]}
-            end
-
-          _ ->
-            {acc, missing}
-        end
-      end)
-
-    # Try DB for misses
-    {db_hits, still_missing} =
-      Enum.reduce(misses, {%{}, []}, fn {id, date, ev}, {acc, miss2} ->
-        case NotesStore.get(id, date) do
-          {:ok, note} ->
-            CacheStore.put({:meeting_notes, id, date}, note)
-            {Map.put(acc, id, note), miss2}
-
-          :not_found ->
-            {acc, [{id, date, ev} | miss2]}
-        end
-      end)
-
+    {hits, misses} = partition_cache_hits(events)
+    {db_hits, still_missing} = fetch_db_for_misses(misses)
     remaining_events = Enum.map(still_missing, fn {_id, _date, ev} -> ev end)
 
-    with {:ok, fetched_map} <-
-           fetch_batch_and_persist(still_missing, remaining_events, opts) do
+    with {:ok, fetched_map} <- fetch_batch_and_persist(still_missing, remaining_events, opts) do
       {:ok, Map.merge(hits, Map.merge(db_hits, fetched_map))}
     end
   end
@@ -117,6 +87,36 @@ defmodule DashboardSSD.Meetings.Notes do
       transcript_id: attrs.transcript_id,
       fetched_at: attrs.fetched_at
     })
+  end
+
+  defp partition_cache_hits(events) do
+    Enum.reduce(events, {%{}, []}, fn ev, {acc, missing} ->
+      case event_id_and_date(ev) do
+        {:ok, id, date} ->
+          key = {:meeting_notes, id, date}
+
+          case CacheStore.get(key) do
+            {:ok, note} -> {Map.put(acc, id, note), missing}
+            :miss -> {acc, [{id, date, ev} | missing]}
+          end
+
+        _ ->
+          {acc, missing}
+      end
+    end)
+  end
+
+  defp fetch_db_for_misses(misses) do
+    Enum.reduce(misses, {%{}, []}, fn {id, date, ev}, {acc, miss2} ->
+      case NotesStore.get(id, date) do
+        {:ok, note} ->
+          CacheStore.put({:meeting_notes, id, date}, note)
+          {Map.put(acc, id, note), miss2}
+
+        :not_found ->
+          {acc, [{id, date, ev} | miss2]}
+      end
+    end)
   end
 
   defp fetch_batch_and_persist([], _events, _opts), do: {:ok, %{}}

--- a/lib/dashboard_ssd/meetings/notes.ex
+++ b/lib/dashboard_ssd/meetings/notes.ex
@@ -39,16 +39,20 @@ defmodule DashboardSSD.Meetings.Notes do
               {:ok, note}
 
             :not_found ->
-              case Fireflies.fetch_notes_for_event(event, opts) do
-                {:ok, note} = ok ->
-                  persist_and_cache(event, date, note)
-                  ok
+              if Keyword.get(opts, :skip_remote, false) do
+                :not_found
+              else
+                case Fireflies.fetch_notes_for_event(event, opts) do
+                  {:ok, note} = ok ->
+                    persist_and_cache(event, date, note)
+                    ok
 
-                :not_found ->
-                  :not_found
+                  :not_found ->
+                    :not_found
 
-                {:error, _} = err ->
-                  err
+                  {:error, _} = err ->
+                    err
+                end
               end
           end
       end
@@ -143,19 +147,23 @@ defmodule DashboardSSD.Meetings.Notes do
   defp fetch_batch_and_persist([], _events, _opts), do: {:ok, %{}}
 
   defp fetch_batch_and_persist(still_missing, events, opts) do
-    case Fireflies.fetch_notes_for_events(events, opts) do
-      {:ok, mapped} when is_map(mapped) ->
-        Enum.each(still_missing, fn {id, date, ev} ->
-          case Map.get(mapped, id) do
-            nil -> :noop
-            note -> persist_and_cache(ev, date, note)
-          end
-        end)
+    if Keyword.get(opts, :skip_remote, false) do
+      {:ok, %{}}
+    else
+      case Fireflies.fetch_notes_for_events(events, opts) do
+        {:ok, mapped} when is_map(mapped) ->
+          Enum.each(still_missing, fn {id, date, ev} ->
+            case Map.get(mapped, id) do
+              nil -> :noop
+              note -> persist_and_cache(ev, date, note)
+            end
+          end)
 
-        {:ok, mapped}
+          {:ok, mapped}
 
-      {:error, _} = err ->
-        err
+        {:error, _} = err ->
+          err
+      end
     end
   end
 end

--- a/lib/dashboard_ssd/meetings/notes.ex
+++ b/lib/dashboard_ssd/meetings/notes.ex
@@ -90,20 +90,23 @@ defmodule DashboardSSD.Meetings.Notes do
   end
 
   defp partition_cache_hits(events) do
-    Enum.reduce(events, {%{}, []}, fn ev, {acc, missing} ->
-      case event_id_and_date(ev) do
-        {:ok, id, date} ->
-          key = {:meeting_notes, id, date}
+    Enum.reduce(events, {%{}, []}, &partition_event/2)
+  end
 
-          case CacheStore.get(key) do
-            {:ok, note} -> {Map.put(acc, id, note), missing}
-            :miss -> {acc, [{id, date, ev} | missing]}
-          end
+  defp partition_event(ev, {acc, missing}) do
+    case event_id_and_date(ev) do
+      {:ok, id, date} -> partition_by_cache(id, date, ev, acc, missing)
+      _ -> {acc, missing}
+    end
+  end
 
-        _ ->
-          {acc, missing}
-      end
-    end)
+  defp partition_by_cache(id, date, ev, acc, missing) do
+    key = {:meeting_notes, id, date}
+
+    case CacheStore.get(key) do
+      {:ok, note} -> {Map.put(acc, id, note), missing}
+      :miss -> {acc, [{id, date, ev} | missing]}
+    end
   end
 
   defp fetch_db_for_misses(misses) do

--- a/lib/dashboard_ssd/meetings/notes.ex
+++ b/lib/dashboard_ssd/meetings/notes.ex
@@ -169,23 +169,25 @@ defmodule DashboardSSD.Meetings.Notes do
   end
 
   defp fetch_remote_and_persist(event, opts) do
-    if Keyword.get(opts, :skip_remote, false) do
-      :not_found
-    else
-      if future_event?(event) do
+    case {Keyword.get(opts, :skip_remote, false), future_event?(event), event_id_and_date(event)} do
+      {true, _fut, _eid} ->
         :not_found
-      else
-        with {:ok, _event_id, date} <- event_id_and_date(event) do
-          case Fireflies.fetch_notes_for_event(event, opts) do
-            {:ok, note} = ok ->
-              persist_and_cache(event, date, note)
-              ok
 
-            other ->
-              other
-          end
+      {false, true, _eid} ->
+        :not_found
+
+      {false, false, {:ok, _event_id, date}} ->
+        case Fireflies.fetch_notes_for_event(event, opts) do
+          {:ok, note} = ok ->
+            persist_and_cache(event, date, note)
+            ok
+
+          other ->
+            other
         end
-      end
+
+      {false, false, {:error, _} = err} ->
+        err
     end
   end
 

--- a/lib/dashboard_ssd/meetings/notes.ex
+++ b/lib/dashboard_ssd/meetings/notes.ex
@@ -185,9 +185,6 @@ defmodule DashboardSSD.Meetings.Notes do
           other ->
             other
         end
-
-      {false, false, {:error, _} = err} ->
-        err
     end
   end
 

--- a/lib/dashboard_ssd/meetings/notes.ex
+++ b/lib/dashboard_ssd/meetings/notes.ex
@@ -25,37 +25,12 @@ defmodule DashboardSSD.Meetings.Notes do
   """
   @spec get_or_fetch(event_map, keyword()) :: {:ok, note_map} | :not_found | {:error, term}
   def get_or_fetch(event, opts \\ []) when is_map(event) do
-    with {:ok, event_id, date} <- event_id_and_date(event) do
-      key = {:meeting_notes, event_id, date}
-
-      case CacheStore.get(key) do
-        {:ok, note} ->
-          {:ok, note}
-
-        :miss ->
-          case NotesStore.get(event_id, date) do
-            {:ok, note} ->
-              CacheStore.put(key, note)
-              {:ok, note}
-
-            :not_found ->
-              if Keyword.get(opts, :skip_remote, false) do
-                :not_found
-              else
-                case Fireflies.fetch_notes_for_event(event, opts) do
-                  {:ok, note} = ok ->
-                    persist_and_cache(event, date, note)
-                    ok
-
-                  :not_found ->
-                    :not_found
-
-                  {:error, _} = err ->
-                    err
-                end
-              end
-          end
-      end
+    with {:ok, event_id, date} <- event_id_and_date(event),
+         {:ok, note} <- get_from_cache_or_db(event_id, date) do
+      {:ok, note}
+    else
+      :miss -> fetch_remote_and_persist(event, opts)
+      {:error, _} = err -> err
     end
   end
 
@@ -156,17 +131,55 @@ defmodule DashboardSSD.Meetings.Notes do
 
     case result do
       {:ok, mapped} when is_map(mapped) ->
-        Enum.each(still_missing, fn {id, date, ev} ->
-          case Map.get(mapped, id) do
-            nil -> :noop
-            note -> persist_and_cache(ev, date, note)
-          end
-        end)
+        Enum.each(still_missing, &persist_if_present(&1, mapped))
 
         {:ok, mapped}
 
       {:error, _} = err ->
         err
+    end
+  end
+
+  defp get_from_cache_or_db(event_id, date) do
+    key = {:meeting_notes, event_id, date}
+
+    case CacheStore.get(key) do
+      {:ok, note} ->
+        {:ok, note}
+
+      :miss ->
+        case NotesStore.get(event_id, date) do
+          {:ok, note} ->
+            CacheStore.put(key, note)
+            {:ok, note}
+
+          :not_found ->
+            :miss
+        end
+    end
+  end
+
+  defp fetch_remote_and_persist(event, opts) do
+    if Keyword.get(opts, :skip_remote, false) do
+      :not_found
+    else
+      with {:ok, event_id, date} <- event_id_and_date(event) do
+        case Fireflies.fetch_notes_for_event(event, opts) do
+          {:ok, note} = ok ->
+            persist_and_cache(event, date, note)
+            ok
+
+          other ->
+            other
+        end
+      end
+    end
+  end
+
+  defp persist_if_present({id, date, ev}, mapped) do
+    case Map.get(mapped, id) do
+      nil -> :noop
+      note -> persist_and_cache(ev, date, note)
     end
   end
 end

--- a/lib/dashboard_ssd/meetings/notes.ex
+++ b/lib/dashboard_ssd/meetings/notes.ex
@@ -129,7 +129,13 @@ defmodule DashboardSSD.Meetings.Notes do
       if Keyword.get(opts, :skip_remote, false) do
         {:ok, %{}}
       else
-        Fireflies.fetch_notes_for_events(events, opts)
+        fetchable_events = Enum.reject(events, &future_event?/1)
+
+        if fetchable_events == [] do
+          {:ok, %{}}
+        else
+          Fireflies.fetch_notes_for_events(fetchable_events, opts)
+        end
       end
 
     case result do
@@ -166,14 +172,18 @@ defmodule DashboardSSD.Meetings.Notes do
     if Keyword.get(opts, :skip_remote, false) do
       :not_found
     else
-      with {:ok, _event_id, date} <- event_id_and_date(event) do
-        case Fireflies.fetch_notes_for_event(event, opts) do
-          {:ok, note} = ok ->
-            persist_and_cache(event, date, note)
-            ok
+      if future_event?(event) do
+        :not_found
+      else
+        with {:ok, _event_id, date} <- event_id_and_date(event) do
+          case Fireflies.fetch_notes_for_event(event, opts) do
+            {:ok, note} = ok ->
+              persist_and_cache(event, date, note)
+              ok
 
-          other ->
-            other
+            other ->
+              other
+          end
         end
       end
     end

--- a/lib/dashboard_ssd/meetings/notes.ex
+++ b/lib/dashboard_ssd/meetings/notes.ex
@@ -1,0 +1,161 @@
+defmodule DashboardSSD.Meetings.Notes do
+  @moduledoc """
+  Orchestrates meeting notes retrieval for a specific event occurrence using
+  cache → DB → remote (Fireflies) strategy. Supports batched retrieval.
+  """
+
+  alias DashboardSSD.Meetings.{CacheStore, NotesStore}
+  alias DashboardSSD.Integrations.Fireflies
+
+  @type event_map :: map()
+  @type note_map :: %{
+          accomplished: String.t() | nil,
+          action_items: [String.t()],
+          bullet_gist: String.t() | nil,
+          transcript_id: String.t() | nil,
+          fetched_at: DateTime.t() | nil
+        }
+
+  @doc """
+  Retrieves notes for a single event occurrence.
+
+  Expects an event map including at least `:id` and `:occurrence_date`. If
+  `:occurrence_date` is not present, attempts to derive it from `:starts_at`
+  (UTC date) as a best effort.
+  """
+  @spec get_or_fetch(event_map, keyword()) :: {:ok, note_map} | :not_found | {:error, term}
+  def get_or_fetch(event, opts \\ []) when is_map(event) do
+    with {:ok, event_id, date} <- event_id_and_date(event) do
+      key = {:meeting_notes, event_id, date}
+
+      case CacheStore.get(key) do
+        {:ok, note} ->
+          {:ok, note}
+
+        :miss ->
+          case NotesStore.get(event_id, date) do
+            {:ok, note} ->
+              CacheStore.put(key, note)
+              {:ok, note}
+
+            :not_found ->
+              case Fireflies.fetch_notes_for_event(event, opts) do
+                {:ok, note} = ok ->
+                  persist_and_cache(event, date, note)
+                  ok
+
+                :not_found ->
+                  :not_found
+
+                {:error, _} = err ->
+                  err
+              end
+          end
+      end
+    end
+  end
+
+  @doc """
+  Retrieves notes for multiple events in a batch. Returns a map of
+  `event_id => note_map` for the matched subset.
+  """
+  @spec get_or_fetch_many([event_map], keyword()) :: {:ok, map()} | {:error, term}
+  def get_or_fetch_many(events, opts \\ []) when is_list(events) do
+    # Partition cache hits and misses
+    {hits, misses} =
+      events
+      |> Enum.reduce({%{}, []}, fn ev, {acc, missing} ->
+        case event_id_and_date(ev) do
+          {:ok, id, date} ->
+            key = {:meeting_notes, id, date}
+
+            case CacheStore.get(key) do
+              {:ok, note} -> {Map.put(acc, id, note), missing}
+              :miss -> {acc, [{id, date, ev} | missing]}
+            end
+
+          _ ->
+            {acc, missing}
+        end
+      end)
+
+    # Try DB for misses
+    {db_hits, still_missing} =
+      Enum.reduce(misses, {%{}, []}, fn {id, date, ev}, {acc, miss2} ->
+        case NotesStore.get(id, date) do
+          {:ok, note} ->
+            CacheStore.put({:meeting_notes, id, date}, note)
+            {Map.put(acc, id, note), miss2}
+
+          :not_found ->
+            {acc, [{id, date, ev} | miss2]}
+        end
+      end)
+
+    remaining_events = Enum.map(still_missing, fn {_id, _date, ev} -> ev end)
+
+    with {:ok, fetched_map} <-
+           fetch_batch_and_persist(still_missing, remaining_events, opts) do
+      {:ok, Map.merge(hits, Map.merge(db_hits, fetched_map))}
+    end
+  end
+
+  # -- internals --
+
+  defp event_id_and_date(event) do
+    id = event[:id] || event["id"]
+    date = event[:occurrence_date] || event["occurrence_date"] || derive_date(event)
+
+    cond do
+      is_binary(id) and match?(%Date{}, date) -> {:ok, id, date}
+      not is_binary(id) -> {:error, :invalid_event_id}
+      true -> {:error, :invalid_occurrence_date}
+    end
+  end
+
+  defp derive_date(%{starts_at: %DateTime{} = dt}), do: DateTime.to_date(dt)
+  defp derive_date(%{"starts_at" => %DateTime{} = dt}), do: DateTime.to_date(dt)
+  defp derive_date(_), do: nil
+
+  defp persist_and_cache(event, date, note) do
+    id = event[:id] || event["id"]
+
+    attrs = %{
+      recurring_series_id: event[:recurring_series_id] || event["recurring_series_id"],
+      transcript_id: note[:transcript_id] || note["transcript_id"],
+      accomplished: note[:accomplished] || note["accomplished"],
+      bullet_gist: note[:bullet_gist] || note["bullet_gist"],
+      action_items: note[:action_items] || note["action_items"],
+      fetched_at: note[:fetched_at] || note["fetched_at"] || DateTime.utc_now()
+    }
+
+    :ok = NotesStore.upsert(id, date, attrs)
+
+    CacheStore.put({:meeting_notes, id, date}, %{
+      accomplished: attrs.accomplished,
+      action_items: List.wrap(attrs.action_items),
+      bullet_gist: attrs.bullet_gist,
+      transcript_id: attrs.transcript_id,
+      fetched_at: attrs.fetched_at
+    })
+  end
+
+  defp fetch_batch_and_persist([], _events, _opts), do: {:ok, %{}}
+
+  defp fetch_batch_and_persist(still_missing, events, opts) do
+    case Fireflies.fetch_notes_for_events(events, opts) do
+      {:ok, mapped} when is_map(mapped) ->
+        Enum.each(still_missing, fn {id, date, ev} ->
+          case Map.get(mapped, id) do
+            nil -> :noop
+            note -> persist_and_cache(ev, date, note)
+          end
+        end)
+
+        {:ok, mapped}
+
+      {:error, _} = err ->
+        err
+    end
+  end
+end

--- a/lib/dashboard_ssd/meetings/notes.ex
+++ b/lib/dashboard_ssd/meetings/notes.ex
@@ -163,7 +163,7 @@ defmodule DashboardSSD.Meetings.Notes do
     if Keyword.get(opts, :skip_remote, false) do
       :not_found
     else
-      with {:ok, event_id, date} <- event_id_and_date(event) do
+      with {:ok, _event_id, date} <- event_id_and_date(event) do
         case Fireflies.fetch_notes_for_event(event, opts) do
           {:ok, note} = ok ->
             persist_and_cache(event, date, note)

--- a/lib/dashboard_ssd/meetings/notes_store.ex
+++ b/lib/dashboard_ssd/meetings/notes_store.ex
@@ -60,12 +60,14 @@ defmodule DashboardSSD.Meetings.NotesStore do
         %MeetingNote{}
         |> MeetingNote.changeset(attrs)
         |> Repo.insert()
+
         :ok
 
       %MeetingNote{} = rec ->
         rec
         |> MeetingNote.changeset(attrs)
         |> Repo.update()
+
         :ok
     end
   end
@@ -87,4 +89,3 @@ defmodule DashboardSSD.Meetings.NotesStore do
   defp normalize_items(%{"items" => l}) when is_list(l), do: l
   defp normalize_items(_), do: []
 end
-

--- a/lib/dashboard_ssd/meetings/notes_store.ex
+++ b/lib/dashboard_ssd/meetings/notes_store.ex
@@ -1,0 +1,90 @@
+defmodule DashboardSSD.Meetings.NotesStore do
+  @moduledoc """
+  Persistence helpers for per-occurrence meeting notes.
+
+  Keyed by `calendar_event_id` and `occurrence_date`. Use with
+  `DashboardSSD.Meetings.MeetingNote`.
+  """
+
+  import Ecto.Query
+  alias DashboardSSD.Meetings.MeetingNote
+  alias DashboardSSD.Repo
+
+  @type note_map :: %{
+          accomplished: String.t() | nil,
+          action_items: [String.t()],
+          bullet_gist: String.t() | nil,
+          transcript_id: String.t() | nil,
+          fetched_at: DateTime.t() | nil
+        }
+
+  @doc """
+  Retrieves meeting notes for an event occurrence by event id and date.
+
+  Returns `{:ok, note_map}` when present or `:not_found` otherwise.
+  """
+  @spec get(String.t(), Date.t()) :: {:ok, note_map()} | :not_found
+  def get(event_id, %Date{} = date) when is_binary(event_id) do
+    case Repo.one(
+           from n in MeetingNote,
+             where:
+               n.calendar_event_id == ^event_id and
+                 n.occurrence_date == ^date,
+             limit: 1
+         ) do
+      %MeetingNote{} = rec -> {:ok, to_public(rec)}
+      _ -> :not_found
+    end
+  end
+
+  @doc """
+  Inserts or updates meeting notes for an event occurrence.
+
+  Automatically stamps `fetched_at` when not provided.
+  Always returns `:ok` after attempting the write.
+  """
+  @spec upsert(String.t(), Date.t(), map()) :: :ok
+  def upsert(event_id, %Date{} = date, attrs)
+      when is_binary(event_id) and is_map(attrs) do
+    attrs =
+      attrs
+      |> Map.put(:calendar_event_id, event_id)
+      |> Map.put(:occurrence_date, date)
+      |> Map.put(:fetched_at, Map.get(attrs, :fetched_at) || DateTime.utc_now())
+
+    case Repo.get_by(MeetingNote,
+           calendar_event_id: event_id,
+           occurrence_date: date
+         ) do
+      nil ->
+        %MeetingNote{}
+        |> MeetingNote.changeset(attrs)
+        |> Repo.insert()
+        :ok
+
+      %MeetingNote{} = rec ->
+        rec
+        |> MeetingNote.changeset(attrs)
+        |> Repo.update()
+        :ok
+    end
+  end
+
+  # -- helpers --
+
+  defp to_public(%MeetingNote{} = rec) do
+    %{
+      accomplished: rec.accomplished,
+      action_items: normalize_items(rec.action_items),
+      bullet_gist: rec.bullet_gist,
+      transcript_id: rec.transcript_id,
+      fetched_at: rec.fetched_at
+    }
+  end
+
+  defp normalize_items(nil), do: []
+  defp normalize_items(items) when is_list(items), do: items
+  defp normalize_items(%{"items" => l}) when is_list(l), do: l
+  defp normalize_items(_), do: []
+end
+

--- a/lib/dashboard_ssd_web/live/meeting_live/detail_component.ex
+++ b/lib/dashboard_ssd_web/live/meeting_live/detail_component.ex
@@ -4,7 +4,7 @@ defmodule DashboardSSDWeb.MeetingLive.DetailComponent do
 
   alias DashboardSSD.{Clients, Projects}
   alias DashboardSSD.Integrations.Fireflies
-  alias DashboardSSD.Meetings.{Agenda, Associations}
+  alias DashboardSSD.Meetings.{Agenda, Associations, Notes}
 
   @impl true
   def update(assigns, socket) do
@@ -21,7 +21,8 @@ defmodule DashboardSSDWeb.MeetingLive.DetailComponent do
       (Map.get(assigns || %{}, :params)
        |> then(&(&1 && Map.get(&1, "mock")))) in ["1", "true"]
 
-    {post, post_error} = fetch_post(series_id, mock?, title)
+    {post, post_error} =
+      fetch_post_occurrence(assigns, mock?) || fetch_post(series_id, mock?, title)
 
     agenda_text = build_agenda_text(manual, post)
 
@@ -191,14 +192,12 @@ defmodule DashboardSSDWeb.MeetingLive.DetailComponent do
     series_id = socket.assigns.series_id
     manual = Agenda.list_items(id)
 
-    mock? = Map.get(socket.assigns[:params] || %{}, "mock") in ["1", "true"]
+    mock? =
+      socket.assigns[:mock?] || Map.get(socket.assigns[:params] || %{}, "mock") in ["1", "true"]
 
     {post, post_error} =
-      fetch_post(
-        series_id,
-        mock?,
-        socket.assigns[:title]
-      )
+      fetch_post_occurrence(socket.assigns, mock?) ||
+        fetch_post(series_id, mock?, socket.assigns[:title])
 
     agenda_text = build_agenda_text(manual, post)
 
@@ -213,6 +212,36 @@ defmodule DashboardSSDWeb.MeetingLive.DetailComponent do
   end
 
   # ======= helpers extracted to reduce complexity =======
+
+  defp fetch_post_occurrence(assigns, mock?) do
+    with %DateTime{} = s <- assigns[:starts_at],
+         %DateTime{} = e <- assigns[:ends_at] do
+      event = %{
+        id: assigns[:meeting_id] || assigns[:id],
+        starts_at: s,
+        ends_at: e,
+        title: assigns[:title],
+        recurring_series_id: assigns[:series_id]
+      }
+
+      case Notes.get_or_fetch(event, skip_remote: !!mock?) do
+        {:ok, note} ->
+          {%{accomplished: note[:accomplished], action_items: note[:action_items]}, nil}
+
+        :not_found ->
+          nil
+
+        {:error, {:rate_limited, msg}} ->
+          {%{accomplished: nil, action_items: []}, %{type: :rate_limited, message: msg}}
+
+        {:error, _} ->
+          {%{accomplished: nil, action_items: []},
+           %{type: :generic, message: "Fireflies data unavailable. Please try again later."}}
+      end
+    else
+      _ -> nil
+    end
+  end
 
   defp fetch_post(nil, _mock?, _title), do: {%{accomplished: nil, action_items: []}, nil}
 

--- a/lib/dashboard_ssd_web/live/meeting_live/detail_component.ex
+++ b/lib/dashboard_ssd_web/live/meeting_live/detail_component.ex
@@ -76,7 +76,17 @@ defmodule DashboardSSDWeb.MeetingLive.DetailComponent do
         {:noreply, socket}
 
       s ->
-        _ = Fireflies.refresh_series(s)
+        res = Fireflies.refresh_series(s)
+
+        socket =
+          case res do
+            {:error, {:rate_limited, msg}} ->
+              assign(socket, post_error: %{type: :rate_limited, message: msg})
+
+            _ ->
+              socket
+          end
+
         refresh_assigns(socket)
     end
   end
@@ -196,6 +206,9 @@ defmodule DashboardSSDWeb.MeetingLive.DetailComponent do
       fetch_post_occurrence(socket.assigns, mock?) ||
         {%{accomplished: nil, action_items: []}, nil}
 
+    # Preserve any existing error (e.g., rate limited) if we didn't get a new one
+    final_error = post_error || socket.assigns[:post_error]
+
     agenda_text = build_agenda_text(manual, post)
 
     {:noreply,
@@ -204,7 +217,7 @@ defmodule DashboardSSDWeb.MeetingLive.DetailComponent do
        summary_text: post.accomplished,
        action_items: normalize_action_items(post.action_items),
        agenda_text: agenda_text,
-       post_error: post_error
+       post_error: final_error
      )}
   end
 
@@ -290,6 +303,11 @@ defmodule DashboardSSDWeb.MeetingLive.DetailComponent do
 
       <div class="mt-8">
         <h3 class="font-medium">Last meeting summary</h3>
+        <%= if @post_error && @post_error[:type] == :rate_limited do %>
+          <div class="mt-2 text-amber-400 text-sm whitespace-pre-wrap">
+            Fireflies rate limited: {@post_error.message}
+          </div>
+        <% end %>
         <%= if @post_error do %>
           <div class="mt-2 text-red-400 text-sm whitespace-pre-wrap">{@post_error.message}</div>
         <% end %>

--- a/lib/dashboard_ssd_web/live/meeting_live/detail_component.ex
+++ b/lib/dashboard_ssd_web/live/meeting_live/detail_component.ex
@@ -17,9 +17,7 @@ defmodule DashboardSSDWeb.MeetingLive.DetailComponent do
     clients = Clients.list_clients()
     projects = Projects.list_projects()
 
-    mock? =
-      (Map.get(assigns || %{}, :params)
-       |> then(&(&1 && Map.get(&1, "mock")))) in ["1", "true"]
+    mock? = assigns[:mock?] || Map.get(assigns[:params] || %{}, "mock") in ["1", "true"]
 
     {post, post_error} =
       fetch_post_occurrence(assigns, mock?) || {%{accomplished: nil, action_items: []}, nil}
@@ -189,7 +187,6 @@ defmodule DashboardSSDWeb.MeetingLive.DetailComponent do
 
   defp refresh_assigns(socket) do
     id = socket.assigns.meeting_id
-    series_id = socket.assigns.series_id
     manual = Agenda.list_items(id)
 
     mock? =
@@ -243,24 +240,7 @@ defmodule DashboardSSDWeb.MeetingLive.DetailComponent do
     end
   end
 
-  defp fetch_post(nil, _mock?, _title), do: {%{accomplished: nil, action_items: []}, nil}
-
-  defp fetch_post(_series_id, true, _title),
-    do: {%{accomplished: nil, action_items: []}, nil}
-
-  defp fetch_post(series_id, false, title) do
-    case Fireflies.fetch_latest_for_series(series_id, title: title) do
-      {:ok, v} ->
-        {v, nil}
-
-      {:error, {:rate_limited, msg}} ->
-        {%{accomplished: nil, action_items: []}, %{type: :rate_limited, message: msg}}
-
-      {:error, _} ->
-        {%{accomplished: nil, action_items: []},
-         %{type: :generic, message: "Fireflies data unavailable. Please try again later."}}
-    end
-  end
+  # (series fallback fetch removed per Step 5.1)
 
   defp build_agenda_text(manual, post) do
     base =

--- a/lib/dashboard_ssd_web/live/meeting_live/detail_component.ex
+++ b/lib/dashboard_ssd_web/live/meeting_live/detail_component.ex
@@ -22,7 +22,7 @@ defmodule DashboardSSDWeb.MeetingLive.DetailComponent do
        |> then(&(&1 && Map.get(&1, "mock")))) in ["1", "true"]
 
     {post, post_error} =
-      fetch_post_occurrence(assigns, mock?) || fetch_post(series_id, mock?, title)
+      fetch_post_occurrence(assigns, mock?) || {%{accomplished: nil, action_items: []}, nil}
 
     agenda_text = build_agenda_text(manual, post)
 
@@ -197,7 +197,7 @@ defmodule DashboardSSDWeb.MeetingLive.DetailComponent do
 
     {post, post_error} =
       fetch_post_occurrence(socket.assigns, mock?) ||
-        fetch_post(series_id, mock?, socket.assigns[:title])
+        {%{accomplished: nil, action_items: []}, nil}
 
     agenda_text = build_agenda_text(manual, post)
 

--- a/lib/dashboard_ssd_web/live/meetings_live/index.ex
+++ b/lib/dashboard_ssd_web/live/meetings_live/index.ex
@@ -4,7 +4,6 @@ defmodule DashboardSSDWeb.MeetingsLive.Index do
 
   alias DashboardSSD.{Clients, Projects}
   alias DashboardSSD.Integrations
-  alias DashboardSSD.Integrations.Fireflies
   alias DashboardSSD.Meetings.{Agenda, Associations, Notes}
   alias DashboardSSD.Meetings.CacheStore
   alias DashboardSSDWeb.DateHelpers
@@ -591,17 +590,6 @@ defmodule DashboardSSDWeb.MeetingsLive.Index do
 
       Map.put(acc, m.id, text)
     end)
-  end
-
-  defp agenda_from_fireflies_or_empty(_m, true), do: ""
-  defp agenda_from_fireflies_or_empty(%{recurring_series_id: nil}, _mock?), do: ""
-
-  defp agenda_from_fireflies_or_empty(%{recurring_series_id: s} = m, _mock?) do
-    case Fireflies.fetch_latest_for_series(s, title: m.title) do
-      {:ok, %{action_items: items}} when is_list(items) -> Enum.join(items, "\n")
-      {:ok, %{action_items: items}} when is_binary(items) -> items
-      _ -> ""
-    end
   end
 
   defp build_assoc_by_meeting(meetings) do

--- a/lib/dashboard_ssd_web/live/meetings_live/index.ex
+++ b/lib/dashboard_ssd_web/live/meetings_live/index.ex
@@ -551,16 +551,7 @@ defmodule DashboardSSDWeb.MeetingsLive.Index do
   end
 
   defp build_agenda_texts_with_notes(meetings, mock?) do
-    events =
-      Enum.map(meetings, fn m ->
-        %{
-          id: m.id,
-          starts_at: m.start_at,
-          ends_at: m.end_at,
-          title: m.title,
-          recurring_series_id: m[:recurring_series_id]
-        }
-      end)
+    events = Enum.map(meetings, &event_from_meeting/1)
 
     notes_map =
       case Notes.get_or_fetch_many(events, if(mock?, do: [skip_remote: true], else: [])) do
@@ -569,27 +560,35 @@ defmodule DashboardSSDWeb.MeetingsLive.Index do
       end
 
     Enum.reduce(meetings, %{}, fn m, acc ->
-      manual =
-        m.id
-        |> Agenda.list_items()
-        |> Enum.sort_by(& &1.position)
-        |> Enum.map_join("\n", &(&1.text || ""))
-
-      note_text =
-        case Map.get(notes_map, m.id) do
-          %{action_items: items} when is_list(items) and items != [] -> Enum.join(items, "\n")
-          %{accomplished: txt} when is_binary(txt) -> String.trim(txt)
-          _ -> ""
-        end
-
-      text =
-        case String.trim(manual) do
-          "" -> note_text
-          other -> other
-        end
-
-      Map.put(acc, m.id, text)
+      manual_text = manual_agenda_text(m.id)
+      note_text = notes_text_for(meetings_notes: notes_map, meeting: m)
+      Map.put(acc, m.id, if(String.trim(manual_text) == "", do: note_text, else: manual_text))
     end)
+  end
+
+  defp event_from_meeting(m) do
+    %{
+      id: m.id,
+      starts_at: m.start_at,
+      ends_at: m.end_at,
+      title: m.title,
+      recurring_series_id: m[:recurring_series_id]
+    }
+  end
+
+  defp manual_agenda_text(meeting_id) do
+    meeting_id
+    |> Agenda.list_items()
+    |> Enum.sort_by(& &1.position)
+    |> Enum.map_join("\n", &(&1.text || ""))
+  end
+
+  defp notes_text_for(meetings_notes: notes_map, meeting: m) do
+    case Map.get(notes_map, m.id) do
+      %{action_items: items} when is_list(items) and items != [] -> Enum.join(items, "\n")
+      %{accomplished: txt} when is_binary(txt) -> String.trim(txt)
+      _ -> ""
+    end
   end
 
   defp build_assoc_by_meeting(meetings) do

--- a/lib/dashboard_ssd_web/live/meetings_live/index.ex
+++ b/lib/dashboard_ssd_web/live/meetings_live/index.ex
@@ -287,6 +287,9 @@ defmodule DashboardSSDWeb.MeetingsLive.Index do
           meeting_id={@params["id"]}
           series_id={@params["series_id"]}
           title={@params["title"]}
+          starts_at={meeting_field(@meetings, @params["id"], :start_at)}
+          ends_at={meeting_field(@meetings, @params["id"], :end_at)}
+          mock?={Map.get(@params || %{}, "mock") in ["1", "true"]}
         />
       </.modal>
     <% end %>
@@ -645,6 +648,13 @@ defmodule DashboardSSDWeb.MeetingsLive.Index do
     case Date.compare(s, e) do
       :gt -> acc
       _ -> expand_dates(Date.add(s, 1), e, MapSet.put(acc, s))
+    end
+  end
+
+  defp meeting_field(meetings, id, field) do
+    case Enum.find(meetings || [], fn m -> m.id == id end) do
+      nil -> nil
+      m -> Map.get(m, field)
     end
   end
 end

--- a/lib/dashboard_ssd_web/live/meetings_live/index.ex
+++ b/lib/dashboard_ssd_web/live/meetings_live/index.ex
@@ -604,7 +604,6 @@ defmodule DashboardSSDWeb.MeetingsLive.Index do
     end
   end
 
-  defp blank?(nil), do: true
   defp blank?(text) when is_binary(text), do: String.trim(text) == ""
 
   defp build_assoc_by_meeting(meetings) do

--- a/lib/dashboard_ssd_web/live/meetings_live/index.ex
+++ b/lib/dashboard_ssd_web/live/meetings_live/index.ex
@@ -562,10 +562,20 @@ defmodule DashboardSSDWeb.MeetingsLive.Index do
         _ -> %{}
       end
 
+    placeholder = "No notes for this occurrence yet"
+
     Enum.reduce(meetings, %{}, fn m, acc ->
       manual_text = manual_agenda_text(m.id)
       note_text = notes_text_for(meetings_notes: notes_map, meeting: m)
-      Map.put(acc, m.id, if(String.trim(manual_text) == "", do: note_text, else: manual_text))
+
+      text =
+        if String.trim(manual_text) == "" do
+          if String.trim(note_text) == "", do: placeholder, else: note_text
+        else
+          manual_text
+        end
+
+      Map.put(acc, m.id, text)
     end)
   end
 

--- a/lib/dashboard_ssd_web/live/meetings_live/index.ex
+++ b/lib/dashboard_ssd_web/live/meetings_live/index.ex
@@ -5,7 +5,7 @@ defmodule DashboardSSDWeb.MeetingsLive.Index do
   alias DashboardSSD.{Clients, Projects}
   alias DashboardSSD.Integrations
   alias DashboardSSD.Integrations.Fireflies
-  alias DashboardSSD.Meetings.{Agenda, Associations}
+  alias DashboardSSD.Meetings.{Agenda, Associations, Notes}
   alias DashboardSSD.Meetings.CacheStore
   alias DashboardSSDWeb.DateHelpers
   import DashboardSSDWeb.CalendarComponents, only: [month_calendar: 1]
@@ -40,7 +40,7 @@ defmodule DashboardSSDWeb.MeetingsLive.Index do
     has_meetings =
       has_meeting_days(socket.assigns.current_user, month_prev, month_next, tz_offset, mock?)
 
-    agenda_texts = build_agenda_texts(meetings, mock?)
+    agenda_texts = build_agenda_texts_with_notes(meetings, mock?)
     assoc_by_meeting = build_assoc_by_meeting(meetings)
     live_action = live_action_from_params(params)
 
@@ -551,7 +551,24 @@ defmodule DashboardSSDWeb.MeetingsLive.Index do
     end)
   end
 
-  defp build_agenda_texts(meetings, mock?) do
+  defp build_agenda_texts_with_notes(meetings, mock?) do
+    events =
+      Enum.map(meetings, fn m ->
+        %{
+          id: m.id,
+          starts_at: m.start_at,
+          ends_at: m.end_at,
+          title: m.title,
+          recurring_series_id: m[:recurring_series_id]
+        }
+      end)
+
+    notes_map =
+      case Notes.get_or_fetch_many(events, if(mock?, do: [skip_remote: true], else: [])) do
+        {:ok, m} when is_map(m) -> m
+        _ -> %{}
+      end
+
     Enum.reduce(meetings, %{}, fn m, acc ->
       manual =
         m.id
@@ -559,9 +576,16 @@ defmodule DashboardSSDWeb.MeetingsLive.Index do
         |> Enum.sort_by(& &1.position)
         |> Enum.map_join("\n", &(&1.text || ""))
 
+      note_text =
+        case Map.get(notes_map, m.id) do
+          %{action_items: items} when is_list(items) and items != [] -> Enum.join(items, "\n")
+          %{accomplished: txt} when is_binary(txt) -> String.trim(txt)
+          _ -> ""
+        end
+
       text =
         case String.trim(manual) do
-          "" -> agenda_from_fireflies_or_empty(m, mock?)
+          "" -> note_text
           other -> other
         end
 

--- a/lib/dashboard_ssd_web/live/meetings_live/index.ex
+++ b/lib/dashboard_ssd_web/live/meetings_live/index.ex
@@ -567,15 +567,7 @@ defmodule DashboardSSDWeb.MeetingsLive.Index do
     Enum.reduce(meetings, %{}, fn m, acc ->
       manual_text = manual_agenda_text(m.id)
       note_text = notes_text_for(meetings_notes: notes_map, meeting: m)
-
-      text =
-        if String.trim(manual_text) == "" do
-          if String.trim(note_text) == "", do: placeholder, else: note_text
-        else
-          manual_text
-        end
-
-      Map.put(acc, m.id, text)
+      Map.put(acc, m.id, choose_agenda_text(manual_text, note_text, placeholder))
     end)
   end
 
@@ -603,6 +595,17 @@ defmodule DashboardSSDWeb.MeetingsLive.Index do
       _ -> ""
     end
   end
+
+  defp choose_agenda_text(manual_text, note_text, placeholder) do
+    cond do
+      not blank?(manual_text) -> manual_text
+      not blank?(note_text) -> note_text
+      true -> placeholder
+    end
+  end
+
+  defp blank?(nil), do: true
+  defp blank?(text) when is_binary(text), do: String.trim(text) == ""
 
   defp build_assoc_by_meeting(meetings) do
     clients = Clients.list_clients()

--- a/priv/repo/migrations/20260108211033_create_meeting_notes.exs
+++ b/priv/repo/migrations/20260108211033_create_meeting_notes.exs
@@ -1,0 +1,20 @@
+defmodule DashboardSSD.Repo.Migrations.CreateMeetingNotes do
+  use Ecto.Migration
+
+  def change do
+    create table(:meeting_notes) do
+      add :calendar_event_id, :string, null: false
+      add :recurring_series_id, :string
+      add :occurrence_date, :date, null: false
+      add :transcript_id, :string
+      add :accomplished, :text
+      add :bullet_gist, :text
+      add :action_items, :map
+      add :fetched_at, :utc_datetime
+      timestamps(type: :utc_datetime)
+    end
+
+    create unique_index(:meeting_notes, [:calendar_event_id, :occurrence_date])
+    create index(:meeting_notes, [:recurring_series_id, :occurrence_date])
+  end
+end

--- a/specs/001-add-meetings-fireflies/implementation/fireflies_meeting_notes_refactor_plan.md
+++ b/specs/001-add-meetings-fireflies/implementation/fireflies_meeting_notes_refactor_plan.md
@@ -111,6 +111,23 @@ vendor terms.
 - Validation
   - LiveView tests asserting that unrelated notes do not appear and correct ones render.
 
+## Step 5.1 — Occurrence-Only Display (no series fallback in UI)
+- Behavior
+  - When a meeting has not yet occurred OR no per-occurrence notes exist for the
+    selected occurrence (cache/DB/remote all missing), the UI must not display
+    series-level notes for that meeting. Instead, render a friendly placeholder
+    (e.g., “No notes for this occurrence yet”).
+  - Keep the series refresh action available in the detail view, but do not
+    auto-fill the occurrence UI with series artifacts; avoid misleading content.
+- Implementation details
+  - Index and detail: if per-occurrence fetch returns `:not_found` (and meeting
+    `starts_at` is in the future or there is no stored `meeting_notes` record),
+    show the placeholder message and skip series fallback rendering.
+  - Preserve the existing manual agenda override (manual text still wins when present).
+- Tests
+  - Add LV tests for a future-dated meeting and for `:not_found` branches to
+    assert the placeholder renders and that no series data appears in the UI.
+
 ## Step 6 — Batched Fetch Optimization
 - Implementation details
   - Build one transcript window from the current page’s events: `min(starts_at)..max(ends_at)`.

--- a/specs/001-add-meetings-fireflies/implementation/fireflies_meeting_notes_refactor_plan.md
+++ b/specs/001-add-meetings-fireflies/implementation/fireflies_meeting_notes_refactor_plan.md
@@ -1,0 +1,205 @@
+# Meeting Notes Refactor Plan
+
+Align meeting notes to the exact meeting occurrence (event id + date), using a cache → DB → remote
+(Fireflies) flow, with batched fetch support. Prefer project‑centric naming: “meeting notes” instead of
+vendor terms.
+
+## Goals
+- Display the correct notes for each occurrence (calendar event id + occurrence date).
+- Read path: cache → DB → Fireflies. Write‑through on successful fetches (persist + cache).
+- Batch fetch for a date range to avoid N remote calls.
+- Provide IEx commands to validate and tests with mocked Fireflies responses.
+
+## Naming & Scope
+- Schema/module naming: “meeting notes” (not “artifacts”).
+- Keep `fireflies_artifacts` as a transitional/fallback source until full rollout.
+
+## Data Model (DB)
+- New table: `meeting_notes`
+  - `calendar_event_id` (string, NOT NULL) — Google event id
+  - `recurring_series_id` (string, NULL) — Google recurrence id (if any)
+  - `occurrence_date` (date, NOT NULL) — date of the occurrence in the UI/user timezone
+  - `transcript_id` (string, NULL)
+  - `accomplished` (text, NULL)
+  - `bullet_gist` (text, NULL)
+  - `action_items` (map, NULL) — stored as JSONB; normalized to `%{"items" => [..]}`
+  - `fetched_at` (utc_datetime, NULL)
+  - `inserted_at`/`updated_at` (utc_datetime)
+- Indexes/constraints
+  - UNIQUE `[:calendar_event_id, :occurrence_date]`
+  - INDEX on `[:recurring_series_id, :occurrence_date]`
+
+## Cache Strategy
+- Namespace: `meeting_notes`
+- Key: `meeting_notes:<calendar_event_id>:<ISO-date>` (e.g. `meeting_notes:evt-1:2025-12-11`)
+- TTL: 12h (configurable)
+- Value (normalized): `%{action_items: [..], bullet_gist: ..., accomplished: ..., transcript_id: ..., fetched_at: ...}`
+
+---
+
+## Step 1 — Migration + Schema
+- Files
+  - `priv/repo/migrations/*_create_meeting_notes.exs`
+  - `lib/dashboard_ssd/meetings/meeting_note.ex`
+- Implementation details
+  - Create the table/constraints above.
+  - Ecto schema `DashboardSSD.Meetings.MeetingNote` with types/specs and `changeset/2`.
+  - Normalize `action_items` on changeset: when list passed, store as `%{"items" => list}`.
+- Validation
+  - `mix ecto.migrate`
+  - `mix compile`
+
+## Step 2 — Store Layer (DB CRUD)
+- Files
+  - `lib/dashboard_ssd/meetings/notes_store.ex`
+- API
+  - `get(event_id, date) :: {:ok, note_map} | :not_found`
+  - `upsert(event_id, date, attrs) :: :ok`
+- Implementation details
+  - Use `Repo.one` with `calendar_event_id` and `occurrence_date`.
+  - Normalize `action_items` on read to list; map schema → public map.
+  - `upsert/3` auto‑stamps `recurring_series_id` (when provided) and `fetched_at` defaulting to now.
+- Validation
+  - Unit tests (DataCase) for insert/update/read and normalization.
+
+## Step 3 — Fireflies Boundary (Per‑event and Batched)
+- Files
+  - `lib/dashboard_ssd/integrations/fireflies.ex` (extend)
+- API
+  - `fetch_notes_for_event(event_map, opts) :: {:ok, note_map} | :not_found | {:error, term}`
+  - `fetch_notes_for_events(event_maps, opts) :: {:ok, %{event_id => note_map}} | {:error, term}`
+- Inputs (event_map)
+  - `%{id, recurring_series_id, starts_at, ends_at, title, participants, meeting_link}`
+- Implementation details
+  - Prefer exact match by `meeting_link` or remote id if present.
+  - Otherwise query transcripts by `[fromDate..toDate]` around `starts_at..ends_at` (± small tolerance),
+    then filter locally by time proximity and optional title/participants.
+  - Normalize to `%{action_items: [..], bullet_gist: ..., accomplished: ..., transcript_id: ..., fetched_at: ...}`.
+  - Batched: build one window using `min(starts_at)..max(ends_at)`; 1 GraphQL call; map results to events locally.
+- Testing/mocks
+  - Use `Tesla.Mock.mock_global/1` to stub GraphQL responses.
+
+## Step 4 — Orchestration (Cache → DB → Remote)
+- Files
+  - `lib/dashboard_ssd/meetings/notes.ex`
+- API
+  - `get_or_fetch(event_map, opts) :: {:ok, note} | :not_found | {:error, term}`
+  - `get_or_fetch_many(event_maps, opts) :: {:ok, %{event_id => note}}`
+- Implementation details
+  - Cache key = `meeting_notes:<id>:<occurrence_date>`.
+  - Flow for one event:
+    1) Try cache; if hit, return.
+    2) Try DB via `NotesStore.get/2`; on hit, populate cache and return.
+    3) Call Fireflies boundary; on success, `NotesStore.upsert/3` + cache; on `:not_found`, return `:not_found`.
+  - Flow for many events:
+    - Partition into cache hits vs misses; query DB for misses; remaining → single batched remote call.
+- Validation
+  - Unit tests to assert short‑circuiting behavior; partial hits merged correctly.
+
+## Step 5 — LiveView Wiring (Meetings list/detail)
+- Files
+  - `lib/dashboard_ssd_web/live/meetings_live/index.ex`
+  - `lib/dashboard_ssd_web/live/meeting_live/detail_component.ex`
+- Implementation details
+  - After meetings are loaded for the selected range, build `events` list with required fields.
+  - Call `Notes.get_or_fetch_many(events, mock?: params["mock"] == "1")`.
+  - Attach notes per meeting: `meeting.notes` based on `id` + derived `occurrence_date` (see below).
+  - Rendering shows only notes for that occurrence; if absent, show a friendly placeholder.
+- Occurrence date derivation
+  - Use the same timezone logic as the UI (e.g., `tz_offset`/selected date param) to compute the
+    local occurrence date from `starts_at`.
+- Validation
+  - LiveView tests asserting that unrelated notes do not appear and correct ones render.
+
+## Step 6 — Batched Fetch Optimization
+- Implementation details
+  - Build one transcript window from the current page’s events: `min(starts_at)..max(ends_at)`.
+  - Map results to events by `meeting_link` or by nearest timestamp; tolerate small skews.
+  - Persist/cache all matched notes; leave unmatched as `:not_found` without exceptions.
+- Validation
+  - Tests asserting only one external call for multiple events; multiple notes returned and persisted.
+
+## Step 7 — Persistence Rules & Normalization
+- On successful fetch/persist:
+  - Trim strings; coerce `action_items` to list on read; store as `%{"items" => [...]}`.
+  - Always set `fetched_at` to now if missing.
+  - Upsert uniqueness on `[calendar_event_id, occurrence_date]`.
+
+## Step 8 — Testing Plan
+- NotesStore (DataCase)
+  - get/2 returns normalized map; upsert insert/update; unique constraint enforced.
+- Fireflies boundary
+  - Exact match path using `meeting_link`.
+  - Windowed search returns multiple; correct matching by time/title/participants.
+  - `:not_found` path; error propagation (e.g., 429/HTTP error).
+  - Batched query returns notes for multiple events.
+- Orchestration
+  - Cache hit short‑circuits; DB hit fills cache; remote hit persists and caches.
+  - Many: partial cache/DB/remote mix.
+- LiveView
+  - Meetings list and detail render only their own notes; placeholder when absent.
+- Mocks
+  - Use `Tesla.Mock.mock_global/1` in setup; restore adapter on exit where needed.
+
+## Step 9 — IEx Validation
+- Start IEx: `iex -S mix`
+- Example event
+  ```elixir
+  event = %{
+    id: "evt-1",
+    recurring_series_id: "series-1",
+    starts_at: ~U[2025-12-11 17:00:00Z],
+    ends_at: ~U[2025-12-11 18:00:00Z],
+    title: "Weekly – Client A",
+    participants: ["a@x.com", "b@x.com"],
+    meeting_link: "https://meet.google.com/abc",
+    occurrence_date: ~D[2025-12-11]
+  }
+  DashboardSSD.Meetings.Notes.get_or_fetch(event, mock?: true)
+  ```
+- Batch
+  ```elixir
+  events = [event1, event2, event3]
+  DashboardSSD.Meetings.Notes.get_or_fetch_many(events, mock?: true)
+  ```
+- Direct store
+  ```elixir
+  DashboardSSD.Meetings.NotesStore.get("evt-1", ~D[2025-12-11])
+  ```
+
+## Step 10 — Backfill (Optional)
+- For recent ranges (e.g., last 30 days):
+  - Load meetings via existing calendar integration; call `get_or_fetch_many/2` with `mock?: false`.
+  - Seed DB while caching.
+
+## Step 11 — Rollout & Checks
+- Sequence
+  1) Step 1: Schema/migration → compile/migrate.
+  2) Step 2: NotesStore → unit tests green.
+  3) Step 3: Fireflies per‑event/batch APIs → boundary tests green with mocks.
+  4) Step 4: Orchestration → unit tests for cache/DB/remote paths.
+  5) Step 5: LiveView wiring → LV tests assert per‑occurrence notes.
+  6) Step 6: Batched optimization → verify single-call behavior.
+  7) Backfill if desired.
+- Commands
+  - `mix format && mix credo --strict`
+  - `mix test`
+  - `mix dialyzer`
+  - `mix check`
+- Commit guidelines
+  - Atomic commits per step, Angular format, explicit paths staged, run `mix format` before committing.
+
+## Edge Cases & Notes
+- Timezone: compute `occurrence_date` using the same logic as the UI’s current tz (e.g., `tz_offset`).
+- Missing transcripts: return `:not_found`; do not show unrelated notes.
+- Series fallback: keep `fireflies_artifacts` as a temporary fallback; log when used.
+- Errors/rate limits: propagate errors from boundary; cache short TTL negative results only if desired (optional).
+
+## Acceptance Criteria (per step)
+- Step 1: Migration + schema compile and migrate successfully.
+- Step 2: NotesStore read/write paths work; normalization correct.
+- Step 3: Boundary returns correct notes for event and batch with mocks.
+- Step 4: Orchestration respects cache→DB→remote, persists and caches results.
+- Step 5: LiveView shows only the matching occurrence notes.
+- Step 6: Batch fetch reduces remote calls for multiple events.
+- Tests: cover positive/negative paths; no external API calls under MIX_ENV=test.

--- a/test/dashboard_ssd/integrations/fireflies_coverage_test.exs
+++ b/test/dashboard_ssd/integrations/fireflies_coverage_test.exs
@@ -84,22 +84,20 @@ defmodule DashboardSSD.Integrations.FirefliesCoverageTest do
             ""
         end
 
-      cond do
-        String.contains?(q, "query Transcript(") ->
-          json(%{
-            "data" => %{
-              "transcript" => %{
-                "summary" => %{
-                  "action_items" => ["One", "Two"],
-                  "overview" => "Accomplished text",
-                  "bullet_gist" => "Bullet"
-                }
+      if String.contains?(q, "query Transcript(") do
+        json(%{
+          "data" => %{
+            "transcript" => %{
+              "summary" => %{
+                "action_items" => ["One", "Two"],
+                "overview" => "Accomplished text",
+                "bullet_gist" => "Bullet"
               }
             }
-          })
-
-        true ->
-          json(%{"data" => %{}})
+          }
+        })
+      else
+        json(%{"data" => %{}})
       end
     end)
 
@@ -189,16 +187,14 @@ defmodule DashboardSSD.Integrations.FirefliesCoverageTest do
             ""
         end
 
-      cond do
-        String.contains?(q, "query Transcripts(") ->
-          json(%{
-            "errors" => [
-              %{"extensions" => %{"code" => "too_many_requests"}, "message" => "Slow down"}
-            ]
-          })
-
-        true ->
-          json(%{"data" => %{}})
+      if String.contains?(q, "query Transcripts(") do
+        json(%{
+          "errors" => [
+            %{"extensions" => %{"code" => "too_many_requests"}, "message" => "Slow down"}
+          ]
+        })
+      else
+        json(%{"data" => %{}})
       end
     end)
 
@@ -249,12 +245,10 @@ defmodule DashboardSSD.Integrations.FirefliesCoverageTest do
             ""
         end
 
-      cond do
-        String.contains?(q, "query Transcripts(") ->
-          json(%{"data" => %{"transcripts" => transcripts}})
-
-        true ->
-          json(%{"data" => %{}})
+      if String.contains?(q, "query Transcripts(") do
+        json(%{"data" => %{"transcripts" => transcripts}})
+      else
+        json(%{"data" => %{}})
       end
     end)
 
@@ -324,12 +318,10 @@ defmodule DashboardSSD.Integrations.FirefliesCoverageTest do
             ""
         end
 
-      cond do
-        String.contains?(q, "query Transcripts(") ->
-          json(%{"data" => %{"transcripts" => transcripts}})
-
-        true ->
-          json(%{"data" => %{}})
+      if String.contains?(q, "query Transcripts(") do
+        json(%{"data" => %{"transcripts" => transcripts}})
+      else
+        json(%{"data" => %{}})
       end
     end)
 
@@ -362,9 +354,10 @@ defmodule DashboardSSD.Integrations.FirefliesCoverageTest do
             ""
         end
 
-      cond do
-        String.contains?(q, "query Transcripts(") -> json(%{"data" => %{"transcripts" => []}})
-        true -> json(%{"data" => %{}})
+      if String.contains?(q, "query Transcripts(") do
+        json(%{"data" => %{"transcripts" => []}})
+      else
+        json(%{"data" => %{}})
       end
     end)
 
@@ -410,12 +403,10 @@ defmodule DashboardSSD.Integrations.FirefliesCoverageTest do
             ""
         end
 
-      cond do
-        String.contains?(q, "query Transcripts(") ->
-          json(%{"data" => %{"transcripts" => transcripts}})
-
-        true ->
-          json(%{"data" => %{}})
+      if String.contains?(q, "query Transcripts(") do
+        json(%{"data" => %{"transcripts" => transcripts}})
+      else
+        json(%{"data" => %{}})
       end
     end)
 

--- a/test/dashboard_ssd/integrations/fireflies_coverage_test.exs
+++ b/test/dashboard_ssd/integrations/fireflies_coverage_test.exs
@@ -45,15 +45,15 @@ defmodule DashboardSSD.Integrations.FirefliesCoverageTest do
         end
 
       cond do
-        String.contains?(q, "query Bites(") and Map.get(v, "mine") == true ->
-          json(%{"data" => %{"bites" => []}})
-
         String.contains?(q, "query Bites(") and Map.get(v, "my_team") == true ->
           json(%{
             "errors" => [
               %{"extensions" => %{"code" => "too_many_requests"}, "message" => "Slow down"}
             ]
           })
+
+        String.contains?(q, "query Bites(") and Map.get(v, "mine") == true ->
+          json(%{"data" => %{"bites" => []}})
 
         true ->
           json(%{"data" => %{}})
@@ -268,7 +268,8 @@ defmodule DashboardSSD.Integrations.FirefliesCoverageTest do
     # Tms is closer than Tsec
     t_ms = DateTime.add(ref, 60, :second) |> DateTime.to_unix(:millisecond)
     t_sec = DateTime.add(ref, 3600, :second) |> DateTime.to_unix()
-    t_float = t_ms * 1.0
+    # Make float slightly further than ms so ms wins
+    t_float = (t_ms + 2000) * 1.0
 
     ev = %{
       id: "E-CL",

--- a/test/dashboard_ssd/integrations/fireflies_coverage_test.exs
+++ b/test/dashboard_ssd/integrations/fireflies_coverage_test.exs
@@ -1,0 +1,424 @@
+defmodule DashboardSSD.Integrations.FirefliesCoverageTest do
+  use DashboardSSD.DataCase, async: false
+
+  import Tesla.Mock
+  require Logger
+
+  alias DashboardSSD.Integrations.Fireflies
+  alias DashboardSSD.Meetings.{CacheStore, FirefliesStore}
+
+  setup_all do
+    # Ensure a fake token is available for the client in tests
+    Application.put_env(:dashboard_ssd, :integrations, fireflies_api_token: "test-token")
+    :ok
+  end
+
+  setup do
+    CacheStore.reset()
+    on_exit(fn -> CacheStore.reset() end)
+    :ok
+  end
+
+  test "fetch_latest_for_series logs debug and returns rate_limited via team fallback" do
+    # Force Logger debug to execute the deferred debug fun inside fetch
+    orig = Logger.level()
+    Logger.configure(level: :debug)
+    on_exit(fn -> Logger.configure(level: orig) end)
+
+    series_id = "S-RL"
+
+    mock_global(fn %Tesla.Env{method: :post, url: "https://api.fireflies.ai/graphql", body: body} ->
+      {q, v} =
+        cond do
+          is_binary(body) ->
+            case Jason.decode(body) do
+              {:ok, %{"query" => q, "variables" => v}} -> {q, v}
+              {:ok, %{"query" => q}} -> {q, %{}}
+              _ -> {"", %{}}
+            end
+
+          is_map(body) ->
+            {Map.get(body, "query") || "", Map.get(body, "variables") || %{}}
+
+          true ->
+            {"", %{}}
+        end
+
+      cond do
+        String.contains?(q, "query Bites(") and Map.get(v, "mine") == true ->
+          json(%{"data" => %{"bites" => []}})
+
+        String.contains?(q, "query Bites(") and Map.get(v, "my_team") == true ->
+          json(%{
+            "errors" => [
+              %{"extensions" => %{"code" => "too_many_requests"}, "message" => "Slow down"}
+            ]
+          })
+
+        true ->
+          json(%{"data" => %{}})
+      end
+    end)
+
+    assert {:error, {:rate_limited, "Slow down"}} = Fireflies.fetch_latest_for_series(series_id)
+  end
+
+  test "fetch_latest_for_series with cached mapping hits transcript summary and persists (items branch)" do
+    series_id = "S-OK"
+    tid = "T-OK"
+    CacheStore.put({:series_map, series_id}, tid, :timer.hours(24))
+
+    mock_global(fn %Tesla.Env{method: :post, url: "https://api.fireflies.ai/graphql", body: body} ->
+      q =
+        case body do
+          b when is_binary(b) ->
+            case Jason.decode(b) do
+              {:ok, m} -> Map.get(m, "query") || ""
+              _ -> ""
+            end
+
+          m when is_map(m) ->
+            Map.get(m, "query") || ""
+
+          _ ->
+            ""
+        end
+
+      cond do
+        String.contains?(q, "query Transcript(") ->
+          json(%{
+            "data" => %{
+              "transcript" => %{
+                "summary" => %{
+                  "action_items" => ["One", "Two"],
+                  "overview" => "Accomplished text",
+                  "bullet_gist" => "Bullet"
+                }
+              }
+            }
+          })
+
+        true ->
+          json(%{"data" => %{}})
+      end
+    end)
+
+    assert {:ok, %{accomplished: "Accomplished text", action_items: ["One", "Two"]}} =
+             Fireflies.fetch_latest_for_series(series_id)
+
+    # Verify persisted via store (normalize list path exercised)
+    assert {:ok, %{action_items: ["One", "Two"]}} = FirefliesStore.get(series_id)
+  end
+
+  test "search_and_map uses atom :created_from.id and transcript id present (filter and transcript_id match)" do
+    series_id = "S-ATOM"
+
+    mock_global(fn %Tesla.Env{method: :post, url: "https://api.fireflies.ai/graphql", body: body} ->
+      q =
+        case body do
+          b when is_binary(b) ->
+            case Jason.decode(b) do
+              {:ok, m} -> Map.get(m, "query") || ""
+              _ -> ""
+            end
+
+          m when is_map(m) ->
+            Map.get(m, "query") || ""
+
+          _ ->
+            ""
+        end
+
+      cond do
+        String.contains?(q, "query Bites(") ->
+          json(%{
+            "data" => %{
+              "bites" => [
+                %{
+                  "transcript_id" => nil,
+                  "created_at" => "2024-01-01T00:00:00Z",
+                  "created_from" => %{id: "NOPE"}
+                },
+                %{
+                  transcript_id: "T-ATOM",
+                  created_at: "2024-01-02T00:00:00Z",
+                  created_from: %{id: series_id}
+                }
+              ]
+            }
+          })
+
+        String.contains?(q, "query Transcript(") ->
+          json(%{
+            "data" => %{
+              "transcript" => %{
+                "summary" => %{"overview" => "Sum", "action_items" => [], "bullet_gist" => nil}
+              }
+            }
+          })
+
+        true ->
+          json(%{"data" => %{}})
+      end
+    end)
+
+    assert {:ok, %{accomplished: "Sum", action_items: []}} =
+             Fireflies.fetch_latest_for_series(series_id)
+
+    # Mapping cached
+    assert {:ok, "T-ATOM"} = CacheStore.get({:series_map, series_id})
+  end
+
+  test "fetch_notes_for_event returns {:error, {:rate_limited, _}} when transcripts query is rate limited" do
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+    ev = %{id: "E-RL", title: "Weekly", starts_at: now, ends_at: DateTime.add(now, 1800, :second)}
+
+    mock_global(fn %Tesla.Env{method: :post, url: "https://api.fireflies.ai/graphql", body: body} ->
+      q =
+        case body do
+          b when is_binary(b) ->
+            case Jason.decode(b) do
+              {:ok, m} -> Map.get(m, "query") || ""
+              _ -> ""
+            end
+
+          m when is_map(m) ->
+            Map.get(m, "query") || ""
+
+          _ ->
+            ""
+        end
+
+      cond do
+        String.contains?(q, "query Transcripts(") ->
+          json(%{
+            "errors" => [
+              %{"extensions" => %{"code" => "too_many_requests"}, "message" => "Slow down"}
+            ]
+          })
+
+        true ->
+          json(%{"data" => %{}})
+      end
+    end)
+
+    assert {:error, {:rate_limited, _}} = Fireflies.fetch_notes_for_event(ev)
+  end
+
+  test "fetch_notes_for_events maps one event to notes (meeting_link match, map put branch)" do
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+    ev = %{
+      id: "E-MAP",
+      title: "Sync",
+      meeting_link: "https://meet.local/abc",
+      starts_at: now,
+      ends_at: DateTime.add(now, 3600, :second)
+    }
+
+    transcripts = [
+      %{
+        "id" => "T1",
+        "title" => "Something",
+        "date" => DateTime.to_iso8601(now),
+        "meeting_link" => "https://meet.local/abc",
+        "summary" => %{"action_items" => ["x"], "overview" => "Notes", "bullet_gist" => nil}
+      },
+      %{
+        "id" => "T2",
+        "title" => "Other",
+        "date" => DateTime.to_iso8601(DateTime.add(now, 7200, :second)),
+        "meeting_link" => "https://meet.local/other",
+        "summary" => %{"action_items" => [], "overview" => nil, "bullet_gist" => nil}
+      }
+    ]
+
+    mock_global(fn %Tesla.Env{method: :post, url: "https://api.fireflies.ai/graphql", body: body} ->
+      q =
+        case body do
+          b when is_binary(b) ->
+            case Jason.decode(b) do
+              {:ok, m} -> Map.get(m, "query") || ""
+              _ -> ""
+            end
+
+          m when is_map(m) ->
+            Map.get(m, "query") || ""
+
+          _ ->
+            ""
+        end
+
+      cond do
+        String.contains?(q, "query Transcripts(") ->
+          json(%{"data" => %{"transcripts" => transcripts}})
+
+        true ->
+          json(%{"data" => %{}})
+      end
+    end)
+
+    assert {:ok, %{"E-MAP" => %{accomplished: "Notes", action_items: ["x"]}}} =
+             Fireflies.fetch_notes_for_events([ev])
+  end
+
+  test "fetch_notes_for_events returns {:error, :invalid_time} when events have no times" do
+    assert {:error, :invalid_time} = Fireflies.fetch_notes_for_events([%{id: "E-NO-TIME"}], [])
+  end
+
+  test "closest_by_time selected when multiple transcripts with same link (covers float/ms/seconds date parsing too)" do
+    # Build event and transcripts with same link but different date encodings
+    ref = DateTime.utc_now() |> DateTime.truncate(:second)
+    link = "https://meet.local/xyz"
+
+    # Tms is closer than Tsec
+    t_ms = DateTime.add(ref, 60, :second) |> DateTime.to_unix(:millisecond)
+    t_sec = DateTime.add(ref, 3600, :second) |> DateTime.to_unix()
+    t_float = t_ms * 1.0
+
+    ev = %{
+      id: "E-CL",
+      title: "Sync",
+      meeting_link: link,
+      starts_at: ref,
+      ends_at: DateTime.add(ref, 3600, :second)
+    }
+
+    transcripts = [
+      %{
+        "id" => "TF",
+        "title" => "A",
+        "date" => t_float,
+        "meeting_link" => link,
+        "summary" => %{"action_items" => [], "overview" => "F"}
+      },
+      %{
+        "id" => "TM",
+        "title" => "B",
+        "date" => t_ms,
+        "meeting_link" => link,
+        "summary" => %{"action_items" => [], "overview" => "M"}
+      },
+      %{
+        "id" => "TS",
+        "title" => "C",
+        "date" => t_sec,
+        "meeting_link" => link,
+        "summary" => %{"action_items" => [], "overview" => "S"}
+      }
+    ]
+
+    mock_global(fn %Tesla.Env{method: :post, url: "https://api.fireflies.ai/graphql", body: body} ->
+      q =
+        case body do
+          b when is_binary(b) ->
+            case Jason.decode(b) do
+              {:ok, m} -> Map.get(m, "query") || ""
+              _ -> ""
+            end
+
+          m when is_map(m) ->
+            Map.get(m, "query") || ""
+
+          _ ->
+            ""
+        end
+
+      cond do
+        String.contains?(q, "query Transcripts(") ->
+          json(%{"data" => %{"transcripts" => transcripts}})
+
+        true ->
+          json(%{"data" => %{}})
+      end
+    end)
+
+    assert {:ok, %{"E-CL" => %{accomplished: "M"}}} = Fireflies.fetch_notes_for_events([ev])
+  end
+
+  test "no meeting_link falls back to time/title and returns :not_found" do
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+    ev = %{
+      id: "E-NOLINK",
+      title: "Sync",
+      starts_at: now,
+      ends_at: DateTime.add(now, 3600, :second)
+    }
+
+    mock_global(fn %Tesla.Env{method: :post, url: "https://api.fireflies.ai/graphql", body: body} ->
+      q =
+        case body do
+          b when is_binary(b) ->
+            case Jason.decode(b) do
+              {:ok, m} -> Map.get(m, "query") || ""
+              _ -> ""
+            end
+
+          m when is_map(m) ->
+            Map.get(m, "query") || ""
+
+          _ ->
+            ""
+        end
+
+      cond do
+        String.contains?(q, "query Transcripts(") -> json(%{"data" => %{"transcripts" => []}})
+        true -> json(%{"data" => %{}})
+      end
+    end)
+
+    assert :not_found = Fireflies.fetch_notes_for_event(ev)
+  end
+
+  test "meeting_link mismatch leads to :not_found (no candidates within 6h)" do
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+    ev = %{
+      id: "E-NOMATCH",
+      title: "Sync",
+      meeting_link: "https://link/a",
+      starts_at: now,
+      ends_at: DateTime.add(now, 3600, :second)
+    }
+
+    far = DateTime.add(now, 10 * 24 * 3600, :second) |> DateTime.to_iso8601()
+
+    transcripts = [
+      %{
+        "id" => "TX",
+        "title" => "Other",
+        "date" => far,
+        "meeting_link" => "https://link/b",
+        "summary" => %{"action_items" => [], "overview" => nil}
+      }
+    ]
+
+    mock_global(fn %Tesla.Env{method: :post, url: "https://api.fireflies.ai/graphql", body: body} ->
+      q =
+        case body do
+          b when is_binary(b) ->
+            case Jason.decode(b) do
+              {:ok, m} -> Map.get(m, "query") || ""
+              _ -> ""
+            end
+
+          m when is_map(m) ->
+            Map.get(m, "query") || ""
+
+          _ ->
+            ""
+        end
+
+      cond do
+        String.contains?(q, "query Transcripts(") ->
+          json(%{"data" => %{"transcripts" => transcripts}})
+
+        true ->
+          json(%{"data" => %{}})
+      end
+    end)
+
+    assert :not_found = Fireflies.fetch_notes_for_event(ev)
+  end
+end

--- a/test/dashboard_ssd/integrations/fireflies_event_notes_test.exs
+++ b/test/dashboard_ssd/integrations/fireflies_event_notes_test.exs
@@ -23,6 +23,7 @@ defmodule DashboardSSD.Integrations.FirefliesEventNotesTest do
 
   test "fetch_notes_for_event selects by meeting_link when available" do
     now = ~U[2025-12-11 17:00:00Z]
+
     ev = %{
       id: "evt-ml",
       starts_at: now,
@@ -78,6 +79,7 @@ defmodule DashboardSSD.Integrations.FirefliesEventNotesTest do
 
   test "fetch_notes_for_event falls back to nearest time within threshold" do
     now = ~U[2025-12-11 10:00:00Z]
+
     ev = %{
       id: "evt-time",
       starts_at: now,
@@ -123,6 +125,7 @@ defmodule DashboardSSD.Integrations.FirefliesEventNotesTest do
 
   test "fetch_notes_for_event returns :not_found when no suitable transcript" do
     now = ~U[2025-12-11 10:00:00Z]
+
     ev = %{
       id: "evt-none",
       starts_at: now,
@@ -138,9 +141,18 @@ defmodule DashboardSSD.Integrations.FirefliesEventNotesTest do
         if is_binary(query) and String.contains?(query, "query Transcripts(") do
           %Tesla.Env{
             status: 200,
-            body: %{"data" => %{"transcripts" => [
-              %{"id" => "t-too-far", "date" => DateTime.to_iso8601(DateTime.add(now, 9 * 3600, :second)), "summary" => %{"overview" => "far"}}
-            ]}}}
+            body: %{
+              "data" => %{
+                "transcripts" => [
+                  %{
+                    "id" => "t-too-far",
+                    "date" => DateTime.to_iso8601(DateTime.add(now, 9 * 3600, :second)),
+                    "summary" => %{"overview" => "far"}
+                  }
+                ]
+              }
+            }
+          }
         else
           flunk("unexpected request: #{inspect(payload)}")
         end
@@ -152,7 +164,13 @@ defmodule DashboardSSD.Integrations.FirefliesEventNotesTest do
   test "fetch_notes_for_events maps multiple events from single query" do
     base = ~U[2025-12-11 12:00:00Z]
     ev1 = %{id: "evt-1", starts_at: base, ends_at: DateTime.add(base, 3600, :second), title: "A"}
-    ev2 = %{id: "evt-2", starts_at: DateTime.add(base, 7200, :second), ends_at: DateTime.add(base, 10800, :second), title: "B"}
+
+    ev2 = %{
+      id: "evt-2",
+      starts_at: DateTime.add(base, 7200, :second),
+      ends_at: DateTime.add(base, 10800, :second),
+      title: "B"
+    }
 
     Tesla.Mock.mock(fn
       %{method: :post, url: "https://api.fireflies.ai/graphql", body: body} ->
@@ -186,9 +204,11 @@ defmodule DashboardSSD.Integrations.FirefliesEventNotesTest do
         end
     end)
 
-    assert {:ok, %{"evt-1" => %{accomplished: "A-notes", action_items: ["x"], transcript_id: "t-a"},
-                    "evt-2" => %{accomplished: "B-notes", action_items: ["y"], transcript_id: "t-b"}}} =
+    assert {:ok,
+            %{
+              "evt-1" => %{accomplished: "A-notes", action_items: ["x"], transcript_id: "t-a"},
+              "evt-2" => %{accomplished: "B-notes", action_items: ["y"], transcript_id: "t-b"}
+            }} =
              Fireflies.fetch_notes_for_events([ev1, ev2])
   end
 end
-

--- a/test/dashboard_ssd/integrations/fireflies_event_notes_test.exs
+++ b/test/dashboard_ssd/integrations/fireflies_event_notes_test.exs
@@ -211,4 +211,44 @@ defmodule DashboardSSD.Integrations.FirefliesEventNotesTest do
             }} =
              Fireflies.fetch_notes_for_events([ev1, ev2])
   end
+
+  test "accepts numeric epoch date (ms) in transcripts" do
+    now = ~U[2025-12-11 10:00:00Z]
+
+    ev = %{
+      id: "evt-ms",
+      starts_at: now,
+      ends_at: DateTime.add(now, 3600, :second),
+      title: "Standup"
+    }
+
+    Tesla.Mock.mock(fn %{method: :post, url: "https://api.fireflies.ai/graphql", body: body} ->
+      payload = if is_binary(body), do: Jason.decode!(body), else: body
+      query = Map.get(payload, "query") || Map.get(payload, :query)
+
+      if is_binary(query) and String.contains?(query, "query Transcripts(") do
+        %Tesla.Env{
+          status: 200,
+          body: %{
+            "data" => %{
+              "transcripts" => [
+                %{
+                  "id" => "t-ms",
+                  "title" => "Standup",
+                  # epoch milliseconds
+                  "date" => DateTime.to_unix(now, :millisecond),
+                  "summary" => %{"overview" => "MS date", "action_items" => []}
+                }
+              ]
+            }
+          }
+        }
+      else
+        flunk("unexpected request: #{inspect(payload)}")
+      end
+    end)
+
+    assert {:ok, %{accomplished: "MS date", transcript_id: "t-ms"}} =
+             Fireflies.fetch_notes_for_event(ev)
+  end
 end

--- a/test/dashboard_ssd/integrations/fireflies_event_notes_test.exs
+++ b/test/dashboard_ssd/integrations/fireflies_event_notes_test.exs
@@ -107,7 +107,7 @@ defmodule DashboardSSD.Integrations.FirefliesEventNotesTest do
                   %{
                     "id" => "t-far",
                     "title" => "Daily Standup",
-                    "date" => DateTime.to_iso8601(DateTime.add(now, 10_800, :second)),
+                    "date" => DateTime.to_iso8601(DateTime.add(now, 36_000, :second)),
                     "summary" => %{"overview" => "Far", "action_items" => []}
                   }
                 ]
@@ -146,7 +146,7 @@ defmodule DashboardSSD.Integrations.FirefliesEventNotesTest do
                 "transcripts" => [
                   %{
                     "id" => "t-too-far",
-                    "date" => DateTime.to_iso8601(DateTime.add(now, 9_000, :second)),
+                    "date" => DateTime.to_iso8601(DateTime.add(now, 32_400, :second)),
                     "summary" => %{"overview" => "far"}
                   }
                 ]

--- a/test/dashboard_ssd/integrations/fireflies_event_notes_test.exs
+++ b/test/dashboard_ssd/integrations/fireflies_event_notes_test.exs
@@ -107,7 +107,7 @@ defmodule DashboardSSD.Integrations.FirefliesEventNotesTest do
                   %{
                     "id" => "t-far",
                     "title" => "Daily Standup",
-                    "date" => DateTime.to_iso8601(DateTime.add(now, 10 * 3600, :second)),
+                    "date" => DateTime.to_iso8601(DateTime.add(now, 10_800, :second)),
                     "summary" => %{"overview" => "Far", "action_items" => []}
                   }
                 ]
@@ -146,7 +146,7 @@ defmodule DashboardSSD.Integrations.FirefliesEventNotesTest do
                 "transcripts" => [
                   %{
                     "id" => "t-too-far",
-                    "date" => DateTime.to_iso8601(DateTime.add(now, 9 * 3600, :second)),
+                    "date" => DateTime.to_iso8601(DateTime.add(now, 9_000, :second)),
                     "summary" => %{"overview" => "far"}
                   }
                 ]

--- a/test/dashboard_ssd/integrations/fireflies_event_notes_test.exs
+++ b/test/dashboard_ssd/integrations/fireflies_event_notes_test.exs
@@ -1,0 +1,194 @@
+defmodule DashboardSSD.Integrations.FirefliesEventNotesTest do
+  use DashboardSSD.DataCase, async: true
+
+  alias DashboardSSD.Integrations.Fireflies
+
+  setup do
+    prev = Application.get_env(:dashboard_ssd, :integrations)
+
+    Application.put_env(
+      :dashboard_ssd,
+      :integrations,
+      Keyword.merge(prev || [], fireflies_api_token: "tok")
+    )
+
+    on_exit(fn ->
+      if prev,
+        do: Application.put_env(:dashboard_ssd, :integrations, prev),
+        else: Application.delete_env(:dashboard_ssd, :integrations)
+    end)
+
+    :ok
+  end
+
+  test "fetch_notes_for_event selects by meeting_link when available" do
+    now = ~U[2025-12-11 17:00:00Z]
+    ev = %{
+      id: "evt-ml",
+      starts_at: now,
+      ends_at: DateTime.add(now, 3600, :second),
+      title: "Weekly Sync",
+      participants: ["a@example.com"],
+      meeting_link: "https://meet.google.com/abc"
+    }
+
+    Tesla.Mock.mock(fn
+      %{method: :post, url: "https://api.fireflies.ai/graphql", body: body} ->
+        payload = if is_binary(body), do: Jason.decode!(body), else: body
+        query = Map.get(payload, "query") || Map.get(payload, :query)
+
+        if is_binary(query) and String.contains?(query, "query Transcripts(") do
+          %Tesla.Env{
+            status: 200,
+            body: %{
+              "data" => %{
+                "transcripts" => [
+                  %{
+                    "id" => "t-1",
+                    "title" => "Weekly Sync — Team",
+                    "date" => DateTime.to_iso8601(now),
+                    "participants" => ["a@example.com"],
+                    "meeting_link" => "https://meet.google.com/abc",
+                    "summary" => %{
+                      "overview" => "Match by link",
+                      "action_items" => ["1", "2"],
+                      "bullet_gist" => nil
+                    }
+                  },
+                  %{
+                    "id" => "t-2",
+                    "title" => "Something else",
+                    "date" => DateTime.to_iso8601(DateTime.add(now, 7200, :second)),
+                    "participants" => [],
+                    "meeting_link" => "https://meet.google.com/xyz",
+                    "summary" => %{"overview" => "Nope", "action_items" => []}
+                  }
+                ]
+              }
+            }
+          }
+        else
+          flunk("unexpected request: #{inspect(payload)}")
+        end
+    end)
+
+    assert {:ok, %{accomplished: "Match by link", action_items: ["1", "2"], transcript_id: "t-1"}} =
+             Fireflies.fetch_notes_for_event(ev)
+  end
+
+  test "fetch_notes_for_event falls back to nearest time within threshold" do
+    now = ~U[2025-12-11 10:00:00Z]
+    ev = %{
+      id: "evt-time",
+      starts_at: now,
+      ends_at: DateTime.add(now, 3600, :second),
+      title: "Daily Standup"
+    }
+
+    Tesla.Mock.mock(fn
+      %{method: :post, url: "https://api.fireflies.ai/graphql", body: body} ->
+        payload = if is_binary(body), do: Jason.decode!(body), else: body
+        query = Map.get(payload, "query") || Map.get(payload, :query)
+
+        if is_binary(query) and String.contains?(query, "query Transcripts(") do
+          %Tesla.Env{
+            status: 200,
+            body: %{
+              "data" => %{
+                "transcripts" => [
+                  %{
+                    "id" => "t-near",
+                    "title" => "Daily Standup",
+                    "date" => DateTime.to_iso8601(DateTime.add(now, 600, :second)),
+                    "summary" => %{"overview" => "Near", "action_items" => []}
+                  },
+                  %{
+                    "id" => "t-far",
+                    "title" => "Daily Standup",
+                    "date" => DateTime.to_iso8601(DateTime.add(now, 10 * 3600, :second)),
+                    "summary" => %{"overview" => "Far", "action_items" => []}
+                  }
+                ]
+              }
+            }
+          }
+        else
+          flunk("unexpected request: #{inspect(payload)}")
+        end
+    end)
+
+    assert {:ok, %{accomplished: "Near", transcript_id: "t-near"}} =
+             Fireflies.fetch_notes_for_event(ev)
+  end
+
+  test "fetch_notes_for_event returns :not_found when no suitable transcript" do
+    now = ~U[2025-12-11 10:00:00Z]
+    ev = %{
+      id: "evt-none",
+      starts_at: now,
+      ends_at: DateTime.add(now, 3600, :second),
+      title: "Weekly"
+    }
+
+    Tesla.Mock.mock(fn
+      %{method: :post, url: "https://api.fireflies.ai/graphql", body: body} ->
+        payload = if is_binary(body), do: Jason.decode!(body), else: body
+        query = Map.get(payload, "query") || Map.get(payload, :query)
+
+        if is_binary(query) and String.contains?(query, "query Transcripts(") do
+          %Tesla.Env{
+            status: 200,
+            body: %{"data" => %{"transcripts" => [
+              %{"id" => "t-too-far", "date" => DateTime.to_iso8601(DateTime.add(now, 9 * 3600, :second)), "summary" => %{"overview" => "far"}}
+            ]}}}
+        else
+          flunk("unexpected request: #{inspect(payload)}")
+        end
+    end)
+
+    assert :not_found == Fireflies.fetch_notes_for_event(ev)
+  end
+
+  test "fetch_notes_for_events maps multiple events from single query" do
+    base = ~U[2025-12-11 12:00:00Z]
+    ev1 = %{id: "evt-1", starts_at: base, ends_at: DateTime.add(base, 3600, :second), title: "A"}
+    ev2 = %{id: "evt-2", starts_at: DateTime.add(base, 7200, :second), ends_at: DateTime.add(base, 10800, :second), title: "B"}
+
+    Tesla.Mock.mock(fn
+      %{method: :post, url: "https://api.fireflies.ai/graphql", body: body} ->
+        payload = if is_binary(body), do: Jason.decode!(body), else: body
+        query = Map.get(payload, "query") || Map.get(payload, :query)
+
+        if is_binary(query) and String.contains?(query, "query Transcripts(") do
+          %Tesla.Env{
+            status: 200,
+            body: %{
+              "data" => %{
+                "transcripts" => [
+                  %{
+                    "id" => "t-a",
+                    "title" => "A",
+                    "date" => DateTime.to_iso8601(base),
+                    "summary" => %{"overview" => "A-notes", "action_items" => ["x"]}
+                  },
+                  %{
+                    "id" => "t-b",
+                    "title" => "B",
+                    "date" => DateTime.to_iso8601(DateTime.add(base, 7200, :second)),
+                    "summary" => %{"overview" => "B-notes", "action_items" => ["y"]}
+                  }
+                ]
+              }
+            }
+          }
+        else
+          flunk("unexpected request: #{inspect(payload)}")
+        end
+    end)
+
+    assert {:ok, %{"evt-1" => %{accomplished: "A-notes", action_items: ["x"], transcript_id: "t-a"},
+                    "evt-2" => %{accomplished: "B-notes", action_items: ["y"], transcript_id: "t-b"}}} =
+             Fireflies.fetch_notes_for_events([ev1, ev2])
+  end
+end
+

--- a/test/dashboard_ssd/integrations/fireflies_event_notes_test.exs
+++ b/test/dashboard_ssd/integrations/fireflies_event_notes_test.exs
@@ -168,7 +168,7 @@ defmodule DashboardSSD.Integrations.FirefliesEventNotesTest do
     ev2 = %{
       id: "evt-2",
       starts_at: DateTime.add(base, 7200, :second),
-      ends_at: DateTime.add(base, 10800, :second),
+      ends_at: DateTime.add(base, 10_800, :second),
       title: "B"
     }
 

--- a/test/dashboard_ssd/meetings/meeting_note_test.exs
+++ b/test/dashboard_ssd/meetings/meeting_note_test.exs
@@ -1,0 +1,80 @@
+defmodule DashboardSSD.Meetings.MeetingNoteTest do
+  use DashboardSSD.DataCase, async: true
+
+  alias DashboardSSD.Repo
+  alias DashboardSSD.Meetings.MeetingNote
+
+  describe "changeset/2 validations" do
+    test "requires calendar_event_id and occurrence_date" do
+      cs = MeetingNote.changeset(%MeetingNote{}, %{})
+      refute cs.valid?
+      assert %{calendar_event_id: ["can't be blank"], occurrence_date: ["can't be blank"]} =
+               errors_on(cs)
+    end
+  end
+
+  describe "insert + normalization" do
+    test "normalizes action_items list to map with items key" do
+      attrs = %{
+        calendar_event_id: "evt-1",
+        occurrence_date: ~D[2025-12-11],
+        action_items: ["do X", "do Y"],
+        accomplished: "done",
+        bullet_gist: "gist"
+      }
+
+      assert {:ok, rec} =
+               %MeetingNote{}
+               |> MeetingNote.changeset(attrs)
+               |> Repo.insert()
+
+      # Stored as map
+      assert %{"items" => ["do X", "do Y"]} = rec.action_items
+
+      # Read back from DB
+      found =
+        Repo.get_by(MeetingNote,
+          calendar_event_id: "evt-1",
+          occurrence_date: ~D[2025-12-11]
+        )
+
+      assert %MeetingNote{action_items: %{"items" => ["do X", "do Y"]}} = found
+      assert found.accomplished == "done"
+      assert found.bullet_gist == "gist"
+    end
+
+    test "accepts pre-wrapped action_items map and optional fields" do
+      attrs = %{
+        calendar_event_id: "evt-2",
+        recurring_series_id: "series-1",
+        occurrence_date: ~D[2025-12-12],
+        transcript_id: "tr-123",
+        action_items: %{"items" => ["a"]}
+      }
+
+      assert {:ok, %MeetingNote{} = rec} =
+               %MeetingNote{}
+               |> MeetingNote.changeset(attrs)
+               |> Repo.insert()
+
+      assert rec.recurring_series_id == "series-1"
+      assert rec.transcript_id == "tr-123"
+      assert rec.action_items == %{"items" => ["a"]}
+    end
+  end
+
+  describe "unique index on (calendar_event_id, occurrence_date)" do
+    test "prevents duplicates for the same event/date" do
+      common = %{calendar_event_id: "evt-3", occurrence_date: ~D[2025-12-13]}
+
+      assert {:ok, _} =
+               %MeetingNote{} |> MeetingNote.changeset(common) |> Repo.insert()
+
+      assert {:error, changeset} =
+               %MeetingNote{} |> MeetingNote.changeset(common) |> Repo.insert()
+
+      assert %{calendar_event_id: ["has already been taken"]} = errors_on(changeset)
+    end
+  end
+end
+

--- a/test/dashboard_ssd/meetings/meeting_note_test.exs
+++ b/test/dashboard_ssd/meetings/meeting_note_test.exs
@@ -8,6 +8,7 @@ defmodule DashboardSSD.Meetings.MeetingNoteTest do
     test "requires calendar_event_id and occurrence_date" do
       cs = MeetingNote.changeset(%MeetingNote{}, %{})
       refute cs.valid?
+
       assert %{calendar_event_id: ["can't be blank"], occurrence_date: ["can't be blank"]} =
                errors_on(cs)
     end
@@ -77,4 +78,3 @@ defmodule DashboardSSD.Meetings.MeetingNoteTest do
     end
   end
 end
-

--- a/test/dashboard_ssd/meetings/meeting_note_test.exs
+++ b/test/dashboard_ssd/meetings/meeting_note_test.exs
@@ -1,8 +1,8 @@
 defmodule DashboardSSD.Meetings.MeetingNoteTest do
   use DashboardSSD.DataCase, async: true
 
-  alias DashboardSSD.Repo
   alias DashboardSSD.Meetings.MeetingNote
+  alias DashboardSSD.Repo
 
   describe "changeset/2 validations" do
     test "requires calendar_event_id and occurrence_date" do

--- a/test/dashboard_ssd/meetings/notes_batch_optimization_test.exs
+++ b/test/dashboard_ssd/meetings/notes_batch_optimization_test.exs
@@ -1,0 +1,78 @@
+defmodule DashboardSSD.Meetings.NotesBatchOptimizationTest do
+  use DashboardSSD.DataCase, async: true
+
+  alias DashboardSSD.Meetings.Notes
+
+  setup do
+    prev = Application.get_env(:dashboard_ssd, :integrations)
+
+    Application.put_env(
+      :dashboard_ssd,
+      :integrations,
+      Keyword.merge(prev || [], fireflies_api_token: "tok")
+    )
+
+    on_exit(fn ->
+      if prev,
+        do: Application.put_env(:dashboard_ssd, :integrations, prev),
+        else: Application.delete_env(:dashboard_ssd, :integrations)
+    end)
+
+    :ok
+  end
+
+  test "get_or_fetch_many performs a single remote batch call" do
+    base = ~U[2025-12-20 12:00:00Z]
+    ev1 = %{id: "evt-1", starts_at: base, ends_at: DateTime.add(base, 3600, :second), title: "A"}
+
+    ev2 = %{
+      id: "evt-2",
+      starts_at: DateTime.add(base, 7200, :second),
+      ends_at: DateTime.add(base, 10_800, :second),
+      title: "B"
+    }
+
+    parent = self()
+
+    Tesla.Mock.mock(fn
+      %{method: :post, url: "https://api.fireflies.ai/graphql", body: body} ->
+        send(parent, :graphql_called)
+        payload = if is_binary(body), do: Jason.decode!(body), else: body
+        query = Map.get(payload, "query") || Map.get(payload, :query)
+
+        if is_binary(query) and String.contains?(query, "query Transcripts(") do
+          %Tesla.Env{
+            status: 200,
+            body: %{
+              "data" => %{
+                "transcripts" => [
+                  %{
+                    "id" => "t-a",
+                    "title" => "A",
+                    "date" => DateTime.to_iso8601(base),
+                    "summary" => %{"overview" => "A-notes", "action_items" => []}
+                  },
+                  %{
+                    "id" => "t-b",
+                    "title" => "B",
+                    "date" => DateTime.to_iso8601(DateTime.add(base, 7200, :second)),
+                    "summary" => %{"overview" => "B-notes", "action_items" => []}
+                  }
+                ]
+              }
+            }
+          }
+        else
+          flunk("unexpected request: #{inspect(payload)}")
+        end
+    end)
+
+    assert {:ok, map} = Notes.get_or_fetch_many([ev1, ev2])
+    assert map["evt-1"].accomplished == "A-notes"
+    assert map["evt-2"].accomplished == "B-notes"
+
+    # Exactly one GraphQL call for the batch
+    assert_receive :graphql_called, 100
+    refute_receive :graphql_called, 50
+  end
+end

--- a/test/dashboard_ssd/meetings/notes_coverage_test.exs
+++ b/test/dashboard_ssd/meetings/notes_coverage_test.exs
@@ -1,0 +1,62 @@
+defmodule DashboardSSD.Meetings.NotesCoverageTest do
+  use DashboardSSD.DataCase, async: true
+
+  alias DashboardSSD.Meetings.{CacheStore, Notes, NotesStore}
+
+  setup do
+    on_exit(fn -> CacheStore.reset() end)
+    CacheStore.reset()
+    :ok
+  end
+
+  test "invalid event id returns {:error, :invalid_event_id} (hits line 60)" do
+    event = %{id: 123, occurrence_date: ~D[2024-01-01]}
+    assert {:error, :invalid_event_id} = Notes.get_or_fetch(event)
+  end
+
+  test "future event skips remote and returns :not_found (hits line 200)" do
+    future_dt = DateTime.add(DateTime.utc_now(), 3600, :second)
+
+    event = %{
+      id: "evt-future",
+      starts_at: future_dt,
+      occurrence_date: DateTime.to_date(future_dt)
+    }
+
+    assert :not_found = Notes.get_or_fetch(event)
+  end
+
+  test "NotesStore normalizes action_items nil to [] (hits line 87)" do
+    id = "evt-nil-items"
+    date = ~D[2024-01-02]
+
+    :ok =
+      NotesStore.upsert(id, date, %{
+        accomplished: nil,
+        action_items: nil,
+        bullet_gist: nil,
+        transcript_id: nil,
+        fetched_at: DateTime.utc_now()
+      })
+
+    assert {:ok, note} = NotesStore.get(id, date)
+    assert note.action_items == []
+  end
+
+  test "NotesStore normalizes action_items map with items list (hits line 89)" do
+    id = "evt-map-items"
+    date = ~D[2024-01-03]
+
+    :ok =
+      NotesStore.upsert(id, date, %{
+        accomplished: nil,
+        action_items: %{"items" => ["a", "b"]},
+        bullet_gist: nil,
+        transcript_id: nil,
+        fetched_at: DateTime.utc_now()
+      })
+
+    assert {:ok, note} = NotesStore.get(id, date)
+    assert note.action_items == ["a", "b"]
+  end
+end

--- a/test/dashboard_ssd/meetings/notes_store_test.exs
+++ b/test/dashboard_ssd/meetings/notes_store_test.exs
@@ -23,6 +23,34 @@ defmodule DashboardSSD.Meetings.NotesStoreTest do
       assert note.action_items == ["A", "B"]
       assert note.accomplished == nil
     end
+
+    test "normalizes nil action_items to empty list" do
+      {:ok, _} =
+        %MeetingNote{}
+        |> MeetingNote.changeset(%{
+          calendar_event_id: "evt-nil",
+          occurrence_date: ~D[2025-12-20],
+          action_items: nil
+        })
+        |> Repo.insert()
+
+      assert {:ok, note} = NotesStore.get("evt-nil", ~D[2025-12-20])
+      assert note.action_items == []
+    end
+
+    test "normalizes map with items key to list" do
+      {:ok, _} =
+        %MeetingNote{}
+        |> MeetingNote.changeset(%{
+          calendar_event_id: "evt-map",
+          occurrence_date: ~D[2025-12-21],
+          action_items: %{"items" => ["i1", "i2"]}
+        })
+        |> Repo.insert()
+
+      assert {:ok, note} = NotesStore.get("evt-map", ~D[2025-12-21])
+      assert note.action_items == ["i1", "i2"]
+    end
   end
 
   describe "upsert/3" do

--- a/test/dashboard_ssd/meetings/notes_store_test.exs
+++ b/test/dashboard_ssd/meetings/notes_store_test.exs
@@ -51,6 +51,37 @@ defmodule DashboardSSD.Meetings.NotesStoreTest do
       assert {:ok, note} = NotesStore.get("evt-map", ~D[2025-12-21])
       assert note.action_items == ["i1", "i2"]
     end
+
+    test "insert_all with nil action_items normalizes to []" do
+      # Bypass changeset to write raw values
+      Repo.insert_all("meeting_notes", [
+        %{
+          calendar_event_id: "evt-insert-nil",
+          occurrence_date: ~D[2025-12-22],
+          action_items: nil,
+          inserted_at: DateTime.utc_now(),
+          updated_at: DateTime.utc_now()
+        }
+      ])
+
+      assert {:ok, note} = NotesStore.get("evt-insert-nil", ~D[2025-12-22])
+      assert note.action_items == []
+    end
+
+    test "insert_all with items map normalizes to list" do
+      Repo.insert_all("meeting_notes", [
+        %{
+          calendar_event_id: "evt-insert-map",
+          occurrence_date: ~D[2025-12-23],
+          action_items: %{"items" => ["m1", "m2"]},
+          inserted_at: DateTime.utc_now(),
+          updated_at: DateTime.utc_now()
+        }
+      ])
+
+      assert {:ok, note} = NotesStore.get("evt-insert-map", ~D[2025-12-23])
+      assert note.action_items == ["m1", "m2"]
+    end
   end
 
   describe "upsert/3" do

--- a/test/dashboard_ssd/meetings/notes_store_test.exs
+++ b/test/dashboard_ssd/meetings/notes_store_test.exs
@@ -1,0 +1,81 @@
+defmodule DashboardSSD.Meetings.NotesStoreTest do
+  use DashboardSSD.DataCase, async: true
+
+  alias DashboardSSD.Meetings.{MeetingNote, NotesStore}
+  alias DashboardSSD.Repo
+
+  describe "get/2" do
+    test "returns :not_found when no record exists" do
+      assert :not_found == NotesStore.get("evt-none", ~D[2025-12-11])
+    end
+
+    test "returns normalized map when present" do
+      {:ok, _} =
+        %MeetingNote{}
+        |> MeetingNote.changeset(%{
+          calendar_event_id: "evt-1",
+          occurrence_date: ~D[2025-12-11],
+          action_items: ["A", "B"]
+        })
+        |> Repo.insert()
+
+      assert {:ok, note} = NotesStore.get("evt-1", ~D[2025-12-11])
+      assert note.action_items == ["A", "B"]
+      assert note.accomplished == nil
+    end
+  end
+
+  describe "upsert/3" do
+    test "inserts when missing and normalizes action_items list" do
+      assert :ok =
+               NotesStore.upsert("evt-2", ~D[2025-12-12], %{
+                 action_items: ["x", "y"],
+                 bullet_gist: "gist"
+               })
+
+      assert {:ok, note} = NotesStore.get("evt-2", ~D[2025-12-12])
+      assert note.action_items == ["x", "y"]
+      assert note.bullet_gist == "gist"
+    end
+
+    test "updates existing occurrence notes" do
+      # seed initial
+      :ok =
+        NotesStore.upsert("evt-3", ~D[2025-12-13], %{
+          action_items: ["old"],
+          accomplished: "old acc"
+        })
+
+      # update
+      :ok =
+        NotesStore.upsert("evt-3", ~D[2025-12-13], %{
+          action_items: ["new-1", "new-2"],
+          bullet_gist: "new gist"
+        })
+
+      assert {:ok, note} = NotesStore.get("evt-3", ~D[2025-12-13])
+      assert note.action_items == ["new-1", "new-2"]
+      assert note.bullet_gist == "new gist"
+      # accomplished remains from previous record unless overwritten
+      assert note.accomplished == "old acc"
+    end
+
+    test "persists recurring_series_id and transcript_id when provided" do
+      :ok =
+        NotesStore.upsert("evt-4", ~D[2025-12-14], %{
+          recurring_series_id: "series-4",
+          transcript_id: "tr-444"
+        })
+
+      rec =
+        Repo.get_by!(MeetingNote,
+          calendar_event_id: "evt-4",
+          occurrence_date: ~D[2025-12-14]
+        )
+
+      assert rec.recurring_series_id == "series-4"
+      assert rec.transcript_id == "tr-444"
+    end
+  end
+end
+

--- a/test/dashboard_ssd/meetings/notes_store_test.exs
+++ b/test/dashboard_ssd/meetings/notes_store_test.exs
@@ -78,4 +78,3 @@ defmodule DashboardSSD.Meetings.NotesStoreTest do
     end
   end
 end
-

--- a/test/dashboard_ssd/meetings/notes_test.exs
+++ b/test/dashboard_ssd/meetings/notes_test.exs
@@ -1,7 +1,7 @@
 defmodule DashboardSSD.Meetings.NotesTest do
   use DashboardSSD.DataCase, async: false
 
-  alias DashboardSSD.Meetings.{Notes, NotesStore, MeetingNote, CacheStore}
+  alias DashboardSSD.Meetings.{CacheStore, MeetingNote, Notes, NotesStore}
   alias DashboardSSD.Repo
 
   setup do
@@ -119,7 +119,7 @@ defmodule DashboardSSD.Meetings.NotesTest do
     ev2 = %{
       id: "evt-b",
       starts_at: DateTime.add(base, 7200, :second),
-      ends_at: DateTime.add(base, 10800, :second),
+      ends_at: DateTime.add(base, 10_800, :second),
       title: "B"
     }
 

--- a/test/dashboard_ssd/meetings/notes_test.exs
+++ b/test/dashboard_ssd/meetings/notes_test.exs
@@ -231,4 +231,69 @@ defmodule DashboardSSD.Meetings.NotesTest do
     Tesla.Mock.mock(fn _ -> flunk("HTTP should not be called after persistence") end)
     assert {:ok, %{accomplished: "one", action_items: ["I1", "I2"]}} = Notes.get_or_fetch(event)
   end
+
+  test "skips remote fetch for future event" do
+    now = DateTime.utc_now()
+
+    event = %{
+      id: "evt-future",
+      starts_at: DateTime.add(now, 3600, :second),
+      ends_at: DateTime.add(now, 7200, :second),
+      title: "Future Meeting"
+    }
+
+    Tesla.Mock.mock(fn _ -> flunk("HTTP should not be called for future events") end)
+    assert :not_found == Notes.get_or_fetch(event)
+
+    refute Repo.get_by(MeetingNote, calendar_event_id: "evt-future")
+  end
+
+  test "batch skips future events and returns only past mappings" do
+    now = DateTime.utc_now()
+    past = DateTime.add(now, -86_400, :second)
+
+    ev_past = %{
+      id: "evt-past",
+      starts_at: past,
+      ends_at: DateTime.add(past, 3600, :second),
+      title: "Past"
+    }
+
+    ev_future = %{
+      id: "evt-fut2",
+      starts_at: DateTime.add(now, 7200, :second),
+      ends_at: DateTime.add(now, 10_800, :second),
+      title: "Future 2"
+    }
+
+    Tesla.Mock.mock(fn
+      %{method: :post, url: "https://api.fireflies.ai/graphql", body: body} ->
+        payload = if is_binary(body), do: Jason.decode!(body), else: body
+        query = Map.get(payload, "query") || Map.get(payload, :query)
+
+        if is_binary(query) and String.contains?(query, "query Transcripts(") do
+          %Tesla.Env{
+            status: 200,
+            body: %{
+              "data" => %{
+                "transcripts" => [
+                  %{
+                    "id" => "t-past",
+                    "title" => "Past",
+                    "date" => DateTime.to_iso8601(past),
+                    "summary" => %{"overview" => "P", "action_items" => []}
+                  }
+                ]
+              }
+            }
+          }
+        else
+          flunk("unexpected request: #{inspect(payload)}")
+        end
+    end)
+
+    assert {:ok, map} = Notes.get_or_fetch_many([ev_past, ev_future])
+    assert map["evt-past"].accomplished == "P"
+    refute Map.has_key?(map, "evt-fut2")
+  end
 end

--- a/test/dashboard_ssd/meetings/notes_test.exs
+++ b/test/dashboard_ssd/meetings/notes_test.exs
@@ -187,4 +187,48 @@ defmodule DashboardSSD.Meetings.NotesTest do
     assert {:error, {:rate_limited, "rl"}} = Notes.get_or_fetch(event)
     refute Repo.get_by(MeetingNote, calendar_event_id: "evt-err")
   end
+
+  test "subsequent get_or_fetch uses cache/DB and skips HTTP" do
+    base = ~U[2025-12-16 15:00:00Z]
+
+    event = %{
+      id: "evt-cache-http",
+      starts_at: base,
+      ends_at: DateTime.add(base, 3600, :second),
+      title: "Weekly"
+    }
+
+    # First call: seed via remote fetch
+    Tesla.Mock.mock(fn
+      %{method: :post, url: "https://api.fireflies.ai/graphql", body: body} ->
+        payload = if is_binary(body), do: Jason.decode!(body), else: body
+        query = Map.get(payload, "query") || Map.get(payload, :query)
+
+        if is_binary(query) and String.contains?(query, "query Transcripts(") do
+          %Tesla.Env{
+            status: 200,
+            body: %{
+              "data" => %{
+                "transcripts" => [
+                  %{
+                    "id" => "t-first",
+                    "title" => "Weekly",
+                    "date" => DateTime.to_iso8601(base),
+                    "summary" => %{"overview" => "one", "action_items" => ["I1", "I2"]}
+                  }
+                ]
+              }
+            }
+          }
+        else
+          flunk("unexpected request: #{inspect(payload)}")
+        end
+    end)
+
+    assert {:ok, %{accomplished: "one", action_items: ["I1", "I2"]}} = Notes.get_or_fetch(event)
+
+    # Second call: should hit cache/DB and not call HTTP
+    Tesla.Mock.mock(fn _ -> flunk("HTTP should not be called after persistence") end)
+    assert {:ok, %{accomplished: "one", action_items: ["I1", "I2"]}} = Notes.get_or_fetch(event)
+  end
 end

--- a/test/dashboard_ssd/meetings/notes_test.exs
+++ b/test/dashboard_ssd/meetings/notes_test.exs
@@ -1,0 +1,190 @@
+defmodule DashboardSSD.Meetings.NotesTest do
+  use DashboardSSD.DataCase, async: false
+
+  alias DashboardSSD.Meetings.{Notes, NotesStore, MeetingNote, CacheStore}
+  alias DashboardSSD.Repo
+
+  setup do
+    prev = Application.get_env(:dashboard_ssd, :integrations)
+
+    Application.put_env(
+      :dashboard_ssd,
+      :integrations,
+      Keyword.merge(prev || [], fireflies_api_token: "tok")
+    )
+
+    CacheStore.reset()
+
+    on_exit(fn ->
+      if prev,
+        do: Application.put_env(:dashboard_ssd, :integrations, prev),
+        else: Application.delete_env(:dashboard_ssd, :integrations)
+
+      CacheStore.reset()
+    end)
+
+    :ok
+  end
+
+  test "cache hit returns without calling HTTP" do
+    date = ~D[2025-12-11]
+    event = %{id: "evt-cache", occurrence_date: date}
+    note = %{accomplished: "cached", action_items: ["X"], bullet_gist: nil, transcript_id: "t"}
+    CacheStore.put({:meeting_notes, "evt-cache", date}, note)
+
+    Tesla.Mock.mock(fn _ -> flunk("HTTP should not be invoked on cache hit") end)
+
+    assert {:ok, ^note} = Notes.get_or_fetch(event)
+  end
+
+  test "DB hit fills cache and returns note" do
+    date = ~D[2025-12-12]
+    event = %{id: "evt-db", occurrence_date: date}
+
+    :ok =
+      NotesStore.upsert("evt-db", date, %{
+        action_items: ["A"],
+        accomplished: "from db",
+        transcript_id: "t-db"
+      })
+
+    Tesla.Mock.mock(fn _ -> flunk("HTTP should not be invoked when DB has data") end)
+
+    assert {:ok, %{accomplished: "from db", action_items: ["A"], transcript_id: "t-db"}} =
+             Notes.get_or_fetch(event)
+
+    assert {:ok, %{accomplished: "from db"}} =
+             CacheStore.get({:meeting_notes, "evt-db", date})
+  end
+
+  test "remote fetch persists and caches for single event" do
+    base = ~U[2025-12-13 10:00:00Z]
+
+    event = %{
+      id: "evt-remote",
+      starts_at: base,
+      ends_at: DateTime.add(base, 3600, :second),
+      title: "Weekly"
+    }
+
+    Tesla.Mock.mock(fn
+      %{method: :post, url: "https://api.fireflies.ai/graphql", body: body} ->
+        payload = if is_binary(body), do: Jason.decode!(body), else: body
+        query = Map.get(payload, "query") || Map.get(payload, :query)
+
+        if is_binary(query) and String.contains?(query, "query Transcripts(") do
+          %Tesla.Env{
+            status: 200,
+            body: %{
+              "data" => %{
+                "transcripts" => [
+                  %{
+                    "id" => "t-r",
+                    "title" => "Weekly",
+                    "date" => DateTime.to_iso8601(base),
+                    "summary" => %{"overview" => "remote-notes", "action_items" => ["R1", "R2"]}
+                  }
+                ]
+              }
+            }
+          }
+        else
+          flunk("unexpected request: #{inspect(payload)}")
+        end
+    end)
+
+    assert {:ok,
+            %{accomplished: "remote-notes", action_items: ["R1", "R2"], transcript_id: "t-r"}} =
+             Notes.get_or_fetch(event)
+
+    # DB persisted
+    rec =
+      Repo.get_by!(MeetingNote,
+        calendar_event_id: "evt-remote",
+        occurrence_date: DateTime.to_date(base)
+      )
+
+    assert rec.transcript_id == "t-r"
+    assert rec.action_items == %{"items" => ["R1", "R2"]}
+
+    # Cache stored
+    assert {:ok, %{accomplished: "remote-notes"}} =
+             CacheStore.get({:meeting_notes, "evt-remote", DateTime.to_date(base)})
+  end
+
+  test "batched fetch persists and caches multiple events" do
+    base = ~U[2025-12-14 12:00:00Z]
+    ev1 = %{id: "evt-a", starts_at: base, ends_at: DateTime.add(base, 3600, :second), title: "A"}
+
+    ev2 = %{
+      id: "evt-b",
+      starts_at: DateTime.add(base, 7200, :second),
+      ends_at: DateTime.add(base, 10800, :second),
+      title: "B"
+    }
+
+    Tesla.Mock.mock(fn
+      %{method: :post, url: "https://api.fireflies.ai/graphql", body: body} ->
+        payload = if is_binary(body), do: Jason.decode!(body), else: body
+        query = Map.get(payload, "query") || Map.get(payload, :query)
+
+        if is_binary(query) and String.contains?(query, "query Transcripts(") do
+          %Tesla.Env{
+            status: 200,
+            body: %{
+              "data" => %{
+                "transcripts" => [
+                  %{
+                    "id" => "t-a",
+                    "title" => "A",
+                    "date" => DateTime.to_iso8601(base),
+                    "summary" => %{"overview" => "A-notes", "action_items" => ["x"]}
+                  },
+                  %{
+                    "id" => "t-b",
+                    "title" => "B",
+                    "date" => DateTime.to_iso8601(DateTime.add(base, 7200, :second)),
+                    "summary" => %{"overview" => "B-notes", "action_items" => ["y"]}
+                  }
+                ]
+              }
+            }
+          }
+        else
+          flunk("unexpected request: #{inspect(payload)}")
+        end
+    end)
+
+    assert {:ok, map} = Notes.get_or_fetch_many([ev1, ev2])
+    assert map["evt-a"].accomplished == "A-notes"
+    assert map["evt-b"].accomplished == "B-notes"
+
+    # DB checks
+    assert Repo.get_by!(MeetingNote,
+             calendar_event_id: "evt-a",
+             occurrence_date: DateTime.to_date(base)
+           )
+
+    assert Repo.get_by!(MeetingNote,
+             calendar_event_id: "evt-b",
+             occurrence_date: DateTime.to_date(DateTime.add(base, 7200, :second))
+           )
+  end
+
+  test "propagates rate limit error from remote and does not persist" do
+    event = %{
+      id: "evt-err",
+      starts_at: ~U[2025-12-15 09:00:00Z],
+      ends_at: ~U[2025-12-15 10:00:00Z],
+      title: "X"
+    }
+
+    Tesla.Mock.mock(fn
+      %{method: :post, url: "https://api.fireflies.ai/graphql"} ->
+        %Tesla.Env{status: 429, body: %{"errors" => [%{"message" => "rl"}]}}
+    end)
+
+    assert {:error, {:rate_limited, "rl"}} = Notes.get_or_fetch(event)
+    refute Repo.get_by(MeetingNote, calendar_event_id: "evt-err")
+  end
+end

--- a/test/dashboard_ssd/meetings/notes_test.exs
+++ b/test/dashboard_ssd/meetings/notes_test.exs
@@ -334,6 +334,15 @@ defmodule DashboardSSD.Meetings.NotesTest do
     refute Map.has_key?(map, "evt-fut2")
   end
 
+  test "invalid id branch in event_id_and_date (line 60) returns error" do
+    # Ensure we do not attempt any HTTP calls
+    Tesla.Mock.mock(fn _ -> flunk("HTTP should not be called for invalid id") end)
+
+    # id is non-binary to trigger the cond branch at notes.ex:60
+    event = %{id: 123, occurrence_date: ~D[2025-12-24]}
+    assert {:error, :invalid_event_id} = Notes.get_or_fetch(event, skip_remote: true)
+  end
+
   test "get_or_fetch_many triggers invalid id branch in event_id_and_date (line 60)" do
     # One invalid event (non-binary id) and one valid event; skip remote to avoid HTTP
     now = DateTime.utc_now()

--- a/test/dashboard_ssd/meetings/notes_test.exs
+++ b/test/dashboard_ssd/meetings/notes_test.exs
@@ -269,6 +269,52 @@ defmodule DashboardSSD.Meetings.NotesTest do
     assert {:error, {:rate_limited, "batch rl"}} = Notes.get_or_fetch_many([ev])
   end
 
+  test "batch persist_if_present persists mapping for missing event" do
+    base = ~U[2025-12-22 08:00:00Z]
+
+    ev = %{
+      id: "evt-batch-one",
+      starts_at: base,
+      ends_at: DateTime.add(base, 3600, :second),
+      title: "Batch One"
+    }
+
+    Tesla.Mock.mock(fn
+      %{method: :post, url: "https://api.fireflies.ai/graphql", body: body} ->
+        payload = if is_binary(body), do: Jason.decode!(body), else: body
+        query = Map.get(payload, "query") || Map.get(payload, :query)
+
+        if is_binary(query) and String.contains?(query, "query Transcripts(") do
+          %Tesla.Env{
+            status: 200,
+            body: %{
+              "data" => %{
+                "transcripts" => [
+                  %{
+                    "id" => "t-one",
+                    "title" => "Batch One",
+                    "date" => DateTime.to_iso8601(base),
+                    "summary" => %{"overview" => "B1", "action_items" => ["b1"]}
+                  }
+                ]
+              }
+            }
+          }
+        else
+          flunk("unexpected request: #{inspect(payload)}")
+        end
+    end)
+
+    assert {:ok, %{"evt-batch-one" => %{accomplished: "B1", action_items: ["b1"]}}} =
+             Notes.get_or_fetch_many([ev])
+
+    # Persisted via persist_if_present branch
+    assert Repo.get_by!(MeetingNote,
+             calendar_event_id: "evt-batch-one",
+             occurrence_date: DateTime.to_date(base)
+           )
+  end
+
   test "skips remote fetch for future event" do
     now = DateTime.utc_now()
 

--- a/test/dashboard_ssd/meetings/notes_test.exs
+++ b/test/dashboard_ssd/meetings/notes_test.exs
@@ -232,6 +232,43 @@ defmodule DashboardSSD.Meetings.NotesTest do
     assert {:ok, %{accomplished: "one", action_items: ["I1", "I2"]}} = Notes.get_or_fetch(event)
   end
 
+  test "get_or_fetch returns error for invalid event id" do
+    event = %{id: 123, occurrence_date: ~D[2025-12-11]}
+    assert {:error, :invalid_event_id} = Notes.get_or_fetch(event)
+  end
+
+  test "derive_date accepts string keys for starts_at" do
+    base = ~U[2025-12-11 12:00:00Z]
+
+    event = %{
+      "id" => "evt-str",
+      "starts_at" => base,
+      "ends_at" => DateTime.add(base, 3600, :second)
+    }
+
+    Tesla.Mock.mock(fn _ -> flunk("HTTP should be skipped with skip_remote") end)
+    assert :not_found == Notes.get_or_fetch(event, skip_remote: true)
+  end
+
+  test "get_or_fetch_many ignores events with invalid id/date and does not call HTTP" do
+    bad = %{title: "Missing id and starts_at"}
+    Tesla.Mock.mock(fn _ -> flunk("HTTP should not be called for invalid events") end)
+    assert {:ok, %{}} = Notes.get_or_fetch_many([bad])
+  end
+
+  test "batch path propagates rate-limited error" do
+    now = DateTime.utc_now()
+    past = DateTime.add(now, -3600, :second)
+    ev = %{id: "evt-rl-batch", starts_at: past, ends_at: now, title: "A"}
+
+    Tesla.Mock.mock(fn
+      %{method: :post, url: "https://api.fireflies.ai/graphql"} ->
+        %Tesla.Env{status: 429, body: %{"errors" => [%{"message" => "batch rl"}]}}
+    end)
+
+    assert {:error, {:rate_limited, "batch rl"}} = Notes.get_or_fetch_many([ev])
+  end
+
   test "skips remote fetch for future event" do
     now = DateTime.utc_now()
 

--- a/test/dashboard_ssd/meetings/notes_test.exs
+++ b/test/dashboard_ssd/meetings/notes_test.exs
@@ -333,4 +333,20 @@ defmodule DashboardSSD.Meetings.NotesTest do
     assert map["evt-past"].accomplished == "P"
     refute Map.has_key?(map, "evt-fut2")
   end
+
+  test "get_or_fetch_many triggers invalid id branch in event_id_and_date (line 60)" do
+    # One invalid event (non-binary id) and one valid event; skip remote to avoid HTTP
+    now = DateTime.utc_now()
+    past = DateTime.add(now, -3600, :second)
+    bad = %{id: 123, occurrence_date: ~D[2025-12-22]}
+    good = %{id: "evt-good", starts_at: past, ends_at: now, title: "Good"}
+
+    # No HTTP should be called regardless
+    Tesla.Mock.mock(fn _ -> flunk("HTTP should not be called in this test") end)
+
+    # The invalid event hits event_id_and_date/1 cond branch (line 60) indirectly
+    assert {:ok, map} = Notes.get_or_fetch_many([bad, good], skip_remote: true)
+    # No notes returned since skip_remote and nothing in cache/DB
+    assert map == %{}
+  end
 end

--- a/test/dashboard_ssd_web/live/meeting_live/detail_component_events_test.exs
+++ b/test/dashboard_ssd_web/live/meeting_live/detail_component_events_test.exs
@@ -248,15 +248,18 @@ defmodule DashboardSSDWeb.MeetingLive.DetailComponentEventsTest do
     end
   end
 
-  test "shows rate-limited message when Fireflies returns RL (component)", %{conn: conn} do
-    Tesla.Mock.mock(fn
+  test "shows rate-limited notice when per-occurrence fetch is rate-limited", %{conn: conn} do
+    Tesla.Mock.mock_global(fn
       %{method: :post, url: "https://api.fireflies.ai/graphql"} ->
         %Tesla.Env{status: 429, body: %{"errors" => [%{"message" => "too many"}]}}
     end)
 
-    {:ok, _view, html} = live_isolated(conn, NoMockHarness)
+    {:ok, view, html} = live_isolated(conn, NoMockHarness)
     assert html =~ "Last meeting summary"
-    assert html =~ "too many"
+    # Trigger refresh to surface RL message deterministically in this LV process
+    render_click(element(view, "button[phx-click='refresh_post']"))
+    html2 = render(view)
+    assert html2 =~ "Fireflies rate limited: too many"
   end
 
   defmodule DerivedHarness do

--- a/test/dashboard_ssd_web/live/meeting_live/detail_component_events_test.exs
+++ b/test/dashboard_ssd_web/live/meeting_live/detail_component_events_test.exs
@@ -221,11 +221,15 @@ defmodule DashboardSSDWeb.MeetingLive.DetailComponentEventsTest do
 
     @impl true
     def mount(_p, _s, socket) do
+      now = ~U[2025-12-20 12:00:00Z]
+
       {:ok,
        socket
        |> Phoenix.Component.assign(:meeting_id, "evt-rl")
        |> Phoenix.Component.assign(:series_id, "series-rl")
        |> Phoenix.Component.assign(:title, "Weekly – RL")
+       |> Phoenix.Component.assign(:starts_at, now)
+       |> Phoenix.Component.assign(:ends_at, DateTime.add(now, 3600, :second))
        |> Phoenix.Component.assign(:params, %{})}
     end
 
@@ -292,12 +296,11 @@ defmodule DashboardSSDWeb.MeetingLive.DetailComponentEventsTest do
   end
 
   test "derives agenda_text from Fireflies when manual empty (list items)", %{conn: conn} do
-    # Ensure no Tesla calls are needed (we seeded cache)
+    # No series fallback anymore; ensure no remote calls and expect pending
     Tesla.Mock.mock(fn _ -> %Tesla.Env{status: 200, body: %{"data" => %{}}} end)
     {:ok, _view, html} = live_isolated(conn, DerivedHarness)
-    # The textarea includes the derived agenda text
-    assert html =~ ">A"
-    assert html =~ ">B"
+    # Now shows summary pending (occurrence-only)
+    assert html =~ "Summary pending"
   end
 
   defmodule OccurrenceNoNotesHarness do

--- a/test/dashboard_ssd_web/live/meeting_live/detail_component_events_test.exs
+++ b/test/dashboard_ssd_web/live/meeting_live/detail_component_events_test.exs
@@ -4,7 +4,7 @@ defmodule DashboardSSDWeb.MeetingLive.DetailComponentEventsTest do
 
   alias DashboardSSD.Accounts
   alias DashboardSSD.Clients
-  alias DashboardSSD.Meetings.{Agenda, CacheStore}
+  alias DashboardSSD.Meetings.{Agenda, CacheStore, FirefliesStore}
   alias DashboardSSD.Projects
   alias DashboardSSDWeb.MeetingLive.DetailComponent
 
@@ -298,6 +298,57 @@ defmodule DashboardSSDWeb.MeetingLive.DetailComponentEventsTest do
     # The textarea includes the derived agenda text
     assert html =~ ">A"
     assert html =~ ">B"
+  end
+
+  defmodule OccurrenceNoNotesHarness do
+    use Phoenix.LiveView
+    alias DashboardSSDWeb.MeetingLive.DetailComponent
+
+    @impl true
+    def mount(_p, _s, socket) do
+      now = ~U[2025-12-20 12:00:00Z]
+
+      {:ok,
+       socket
+       |> Phoenix.Component.assign(:meeting_id, "evt-occ-none")
+       |> Phoenix.Component.assign(:series_id, "series-occ-none")
+       |> Phoenix.Component.assign(:title, "Weekly – Occ")
+       |> Phoenix.Component.assign(:starts_at, now)
+       |> Phoenix.Component.assign(:ends_at, DateTime.add(now, 3600, :second))
+       |> Phoenix.Component.assign(:params, %{"mock" => "1"})}
+    end
+
+    @impl true
+    def render(assigns) do
+      ~H"""
+      <.live_component
+        module={DetailComponent}
+        id="detail-occ-none"
+        meeting_id={@meeting_id}
+        series_id={@series_id}
+        title={@title}
+        starts_at={@starts_at}
+        ends_at={@ends_at}
+        params={@params}
+      />
+      """
+    end
+  end
+
+  test "detail component shows pending when no per-occurrence notes (no series fallback)", %{
+    conn: conn
+  } do
+    # Seed series data that should NOT appear
+    :ok =
+      FirefliesStore.upsert("series-occ-none", %{
+        accomplished: "Series Should Not Show",
+        action_items: ["X"]
+      })
+
+    {:ok, _view, html} = live_isolated(conn, OccurrenceNoNotesHarness)
+    assert html =~ "Summary pending"
+    refute html =~ "Series Should Not Show"
+    refute html =~ ">X<"
   end
 
   defmodule SuggestHarness do

--- a/test/dashboard_ssd_web/live/meeting_live/detail_component_test.exs
+++ b/test/dashboard_ssd_web/live/meeting_live/detail_component_test.exs
@@ -104,7 +104,7 @@ defmodule DashboardSSDWeb.MeetingLive.DetailComponentTest do
   test "assoc_apply_guess handles client and project via direct event call" do
     # Build a minimal socket assigns for direct handle_event invocation
     socket = %Phoenix.LiveView.Socket{
-      assigns: %{meeting_id: "evt-handle", series_id: "series-handle"}
+      assigns: %{__changed__: %{}, meeting_id: "evt-handle", series_id: "series-handle"}
     }
 
     {:ok, client} = DashboardSSD.Clients.create_client(%{name: "X Co"})

--- a/test/dashboard_ssd_web/live/meeting_live/detail_component_test.exs
+++ b/test/dashboard_ssd_web/live/meeting_live/detail_component_test.exs
@@ -42,10 +42,8 @@ defmodule DashboardSSDWeb.MeetingLive.DetailComponentTest do
       })
 
     assert html =~ "Last meeting summary"
-    assert html =~ "Notes"
-    assert html =~ ">A<"
-    assert html =~ ">B<"
-    # agenda textarea should include manual text, not derived items
+    assert html =~ "Summary pending"
+    # agenda textarea should include manual text
     assert html =~ ">Manual<"
   end
 

--- a/test/dashboard_ssd_web/live/meeting_live/detail_component_test.exs
+++ b/test/dashboard_ssd_web/live/meeting_live/detail_component_test.exs
@@ -47,6 +47,98 @@ defmodule DashboardSSDWeb.MeetingLive.DetailComponentTest do
     assert html =~ ">Manual<"
   end
 
+  test "renders action items from cached per-occurrence string (normalizes via split)" do
+    # Seed per-occurrence cache with string action_items to hit normalization branch
+    id = "evt-str"
+    start = DateTime.utc_now() |> DateTime.truncate(:second)
+    date = DateTime.to_date(start)
+
+    :ok =
+      CacheStore.put(
+        {:meeting_notes, id, date},
+        %{accomplished: nil, action_items: "A\nB"},
+        60_000
+      )
+
+    html =
+      render_detail(%{
+        id: "m-str",
+        meeting_id: id,
+        series_id: nil,
+        title: "Weekly – Items",
+        starts_at: start,
+        ends_at: DateTime.add(start, 3600, :second)
+      })
+
+    assert html =~ "Action Items"
+    assert html =~ ">A<"
+    assert html =~ ">B<"
+  end
+
+  test "renders summary text when present and no action items" do
+    id = "evt-sum"
+    start = DateTime.utc_now() |> DateTime.truncate(:second)
+    date = DateTime.to_date(start)
+
+    :ok =
+      CacheStore.put(
+        {:meeting_notes, id, date},
+        %{accomplished: "Sum text", action_items: []},
+        60_000
+      )
+
+    html =
+      render_detail(%{
+        id: "m-sum",
+        meeting_id: id,
+        series_id: nil,
+        title: "Weekly – Summary",
+        starts_at: start,
+        ends_at: DateTime.add(start, 3600, :second)
+      })
+
+    assert html =~ "Last meeting summary"
+    assert html =~ ">Sum text<"
+  end
+
+  test "assoc_apply_guess handles client and project via direct event call" do
+    # Build a minimal socket assigns for direct handle_event invocation
+    socket = %Phoenix.LiveView.Socket{
+      assigns: %{meeting_id: "evt-handle", series_id: "series-handle"}
+    }
+
+    {:ok, client} = DashboardSSD.Clients.create_client(%{name: "X Co"})
+    {:ok, project} = DashboardSSD.Projects.create_project(%{name: "PX"})
+
+    # Client path
+    {:noreply, sock1} =
+      DetailComponent.handle_event(
+        "assoc_apply_guess",
+        %{"entity" => "client:#{client.id}"},
+        socket
+      )
+
+    assert sock1.assigns[:assoc]
+    assert sock1.assigns[:association]
+
+    # Project path
+    {:noreply, sock2} =
+      DetailComponent.handle_event(
+        "assoc_apply_guess",
+        %{"entity" => "project:#{project.id}"},
+        socket
+      )
+
+    assert sock2.assigns[:assoc]
+    assert sock2.assigns[:association]
+
+    # Invalid entity leaves socket unchanged
+    {:noreply, sock3} =
+      DetailComponent.handle_event("assoc_apply_guess", %{"entity" => "bad:1"}, socket)
+
+    refute Map.has_key?(sock3.assigns, :association)
+  end
+
   test "shows suggested association based on title when none set" do
     # Create a client to match against title
     _ = Accounts.ensure_role!("client")

--- a/test/dashboard_ssd_web/live/meetings_live/index_notes_integration_test.exs
+++ b/test/dashboard_ssd_web/live/meetings_live/index_notes_integration_test.exs
@@ -80,7 +80,9 @@ defmodule DashboardSSDWeb.MeetingsLive.IndexNotesIntegrationTest do
       })
 
     # Do not seed meeting_notes; in mock mode, remote is skipped and per-occurrence is :not_found
-    {:ok, _view, html} = live(conn, ~p"/meetings?mock=1")
+    # Use a future window to avoid any notes seeded by other tests
+    future = Date.add(Date.utc_today(), 30) |> Date.to_iso8601()
+    {:ok, _view, html} = live(conn, ~p"/meetings?mock=1&d=#{future}")
 
     assert html =~ "No notes for this occurrence yet"
     refute html =~ "Series Alpha"

--- a/test/dashboard_ssd_web/live/meetings_live/index_notes_integration_test.exs
+++ b/test/dashboard_ssd_web/live/meetings_live/index_notes_integration_test.exs
@@ -54,7 +54,9 @@ defmodule DashboardSSDWeb.MeetingsLive.IndexNotesIntegrationTest do
     {:ok, _view, html} = live(conn, ~p"/meetings?mock=1")
 
     assert html =~ "Agenda"
-    assert html =~ "Alpha notes"
-    assert html =~ "Contoso notes"
+    # Prefers action_items over accomplished text when present
+    assert html =~ "AX"
+    assert html =~ "AY"
+    assert html =~ "CX"
   end
 end

--- a/test/dashboard_ssd_web/live/meetings_live/index_notes_integration_test.exs
+++ b/test/dashboard_ssd_web/live/meetings_live/index_notes_integration_test.exs
@@ -1,0 +1,60 @@
+defmodule DashboardSSDWeb.MeetingsLive.IndexNotesIntegrationTest do
+  use DashboardSSDWeb.ConnCase, async: true
+  import Phoenix.LiveViewTest
+
+  alias DashboardSSD.Accounts
+
+  setup %{conn: conn} do
+    {:ok, user} =
+      Accounts.create_user(%{
+        email: "meetings_notes@example.com",
+        name: "Mtg Notes",
+        role_id: Accounts.ensure_role!("admin").id
+      })
+
+    prev = Application.get_env(:dashboard_ssd, :integrations)
+
+    Application.put_env(
+      :dashboard_ssd,
+      :integrations,
+      Keyword.merge(prev || [], fireflies_api_token: "tok")
+    )
+
+    on_exit(fn ->
+      if prev,
+        do: Application.put_env(:dashboard_ssd, :integrations, prev),
+        else: Application.delete_env(:dashboard_ssd, :integrations)
+    end)
+
+    {:ok, conn: init_test_session(conn, %{user_id: user.id})}
+  end
+
+  test "renders notes from DB per occurrence (mock mode skips remote)", %{conn: conn} do
+    # Seed MeetingNote records for the two sample mock events
+    selected_date = Date.utc_today()
+    start_date = Date.add(selected_date, -6)
+    {:ok, start_dt} = DateTime.new(start_date, ~T[00:00:00], "Etc/UTC")
+    ev1_date = DateTime.to_date(start_dt)
+    ev2_date = DateTime.to_date(DateTime.add(start_dt, 2 * 3600, :second))
+
+    :ok =
+      DashboardSSD.Meetings.NotesStore.upsert("evt-1", ev1_date, %{
+        accomplished: "Alpha notes",
+        action_items: ["AX", "AY"],
+        transcript_id: "t-alpha"
+      })
+
+    :ok =
+      DashboardSSD.Meetings.NotesStore.upsert("evt-2", ev2_date, %{
+        accomplished: "Contoso notes",
+        action_items: ["CX"],
+        transcript_id: "t-contoso"
+      })
+
+    {:ok, _view, html} = live(conn, ~p"/meetings?mock=1")
+
+    assert html =~ "Agenda"
+    assert html =~ "Alpha notes"
+    assert html =~ "Contoso notes"
+  end
+end

--- a/test/dashboard_ssd_web/live/meetings_live/index_notes_integration_test.exs
+++ b/test/dashboard_ssd_web/live/meetings_live/index_notes_integration_test.exs
@@ -3,8 +3,7 @@ defmodule DashboardSSDWeb.MeetingsLive.IndexNotesIntegrationTest do
   import Phoenix.LiveViewTest
 
   alias DashboardSSD.Accounts
-  alias DashboardSSD.Meetings.FirefliesStore
-  alias DashboardSSD.Meetings.NotesStore
+  alias DashboardSSD.Meetings.{CacheStore, FirefliesStore, NotesStore}
 
   setup %{conn: conn} do
     {:ok, user} =
@@ -22,10 +21,15 @@ defmodule DashboardSSDWeb.MeetingsLive.IndexNotesIntegrationTest do
       Keyword.merge(prev || [], fireflies_api_token: "tok")
     )
 
+    # Ensure cross-test cache isolation (ETS cache is global)
+    CacheStore.reset()
+
     on_exit(fn ->
       if prev,
         do: Application.put_env(:dashboard_ssd, :integrations, prev),
         else: Application.delete_env(:dashboard_ssd, :integrations)
+
+      CacheStore.reset()
     end)
 
     {:ok, conn: init_test_session(conn, %{user_id: user.id})}

--- a/test/dashboard_ssd_web/live/meetings_live/index_notes_integration_test.exs
+++ b/test/dashboard_ssd_web/live/meetings_live/index_notes_integration_test.exs
@@ -3,6 +3,7 @@ defmodule DashboardSSDWeb.MeetingsLive.IndexNotesIntegrationTest do
   import Phoenix.LiveViewTest
 
   alias DashboardSSD.Accounts
+  alias DashboardSSD.Meetings.NotesStore
 
   setup %{conn: conn} do
     {:ok, user} =
@@ -38,14 +39,14 @@ defmodule DashboardSSDWeb.MeetingsLive.IndexNotesIntegrationTest do
     ev2_date = DateTime.to_date(DateTime.add(start_dt, 2 * 3600, :second))
 
     :ok =
-      DashboardSSD.Meetings.NotesStore.upsert("evt-1", ev1_date, %{
+      NotesStore.upsert("evt-1", ev1_date, %{
         accomplished: "Alpha notes",
         action_items: ["AX", "AY"],
         transcript_id: "t-alpha"
       })
 
     :ok =
-      DashboardSSD.Meetings.NotesStore.upsert("evt-2", ev2_date, %{
+      NotesStore.upsert("evt-2", ev2_date, %{
         accomplished: "Contoso notes",
         action_items: ["CX"],
         transcript_id: "t-contoso"

--- a/test/dashboard_ssd_web/live/meetings_live/index_notes_integration_test.exs
+++ b/test/dashboard_ssd_web/live/meetings_live/index_notes_integration_test.exs
@@ -53,7 +53,8 @@ defmodule DashboardSSDWeb.MeetingsLive.IndexNotesIntegrationTest do
         transcript_id: "t-contoso"
       })
 
-    {:ok, _view, html} = live(conn, ~p"/meetings?mock=1")
+    today = Date.utc_today() |> Date.to_iso8601()
+    {:ok, _view, html} = live(conn, ~p"/meetings?mock=1&d=#{today}")
 
     assert html =~ "Agenda"
     # Prefers action_items over accomplished text when present

--- a/test/dashboard_ssd_web/live/meetings_live/index_notes_integration_test.exs
+++ b/test/dashboard_ssd_web/live/meetings_live/index_notes_integration_test.exs
@@ -3,6 +3,7 @@ defmodule DashboardSSDWeb.MeetingsLive.IndexNotesIntegrationTest do
   import Phoenix.LiveViewTest
 
   alias DashboardSSD.Accounts
+  alias DashboardSSD.Meetings.FirefliesStore
   alias DashboardSSD.Meetings.NotesStore
 
   setup %{conn: conn} do
@@ -59,5 +60,27 @@ defmodule DashboardSSDWeb.MeetingsLive.IndexNotesIntegrationTest do
     assert html =~ "AX"
     assert html =~ "AY"
     assert html =~ "CX"
+  end
+
+  test "shows placeholder when no per-occurrence notes and no manual agenda (no series fallback)",
+       %{conn: conn} do
+    # Seed series artifacts that would previously have appeared via fallback
+    :ok =
+      FirefliesStore.upsert("series-alpha", %{accomplished: "Series Alpha", action_items: ["SA"]})
+
+    :ok =
+      FirefliesStore.upsert("series-contoso", %{
+        accomplished: "Series Contoso",
+        action_items: ["SC"]
+      })
+
+    # Do not seed meeting_notes; in mock mode, remote is skipped and per-occurrence is :not_found
+    {:ok, _view, html} = live(conn, ~p"/meetings?mock=1")
+
+    assert html =~ "No notes for this occurrence yet"
+    refute html =~ "Series Alpha"
+    refute html =~ "SA"
+    refute html =~ "Series Contoso"
+    refute html =~ "SC"
   end
 end


### PR DESCRIPTION
refactor functionality for meeting notes

* make sure to cache and load into db for new meeting notes (helps prevent hitting API limiter on fireflies)

* fix how meeting notes are displayed with the specific date - previously displayed meeting notes sequentially with no regard for order/date

* improve test coverage to pass coveralls